### PR TITLE
📝 docs(agents): require PR workflow by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,9 @@ React 19 + TypeScript component library (Vite, Vitest, Storybook, `pnpm@9.15.2`)
 - Issue body: change + acceptance checks.
 - Types: `✨ feat`, `🐛 fix`, `🧹 chore`, `♻️ refactor`, `📝 docs`, `✅ test`, `🎨 style`, `⚡ perf`, `♿ a11y`, `👷 ci`, `🔧 build`.
 - Labels: `type: <emoji> <kind>`; update with `gh label create ... --force`.
-- Flow: `gh issue view` -> implement -> validate -> commit (`Closes #123` / `Fixes #123` when completed; `Refs #123` otherwise) -> push branch -> open PR -> merge -> `gh issue close` only if auto-close did not trigger.
-- Default delivery path: create a branch, push it, and open a PR for every change; do not push directly to `main`.
+- Flow: `gh issue view` -> implement -> validate -> commit (`Closes #123` / `Fixes #123` when completed; `Refs #123` otherwise) -> push branch -> create PR with `gh pr create` -> merge -> `gh issue close` only if auto-close did not trigger.
+- Default delivery path: create a branch, push it, and create a PR for every change; do not push directly to `main`.
+- When asked to "commit and push", treat it as "commit, push, and open a PR" unless the user explicitly says not to create a PR.
 - Optional: `gh issue develop <number> --checkout`.
 - Commits: atomic, imperative subject (<72 chars), 1-3 line body, no literal `\n` in scripted commits (use multiple `-m` flags).
 - Include tests with behavior changes; verify message before push: `git log --format=medium -n 1`.


### PR DESCRIPTION
## Summary
- update AGENTS guidance to require branch + PR workflow for all changes
- make PR creation explicit in flow via `gh pr create`
- treat "commit and push" requests as including PR creation unless user opts out

## Validation
- pre-push checks passed during `git push` (lint, test, build)