### PR TITLE
♻️ refactor(layout): tighten flex and grid layout API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ These conventions describe the library's public component APIs for external cons
 - Components use the React 19 `ref` prop pattern (no `forwardRef` wrapper required for consumers)
 - Some props are intentionally owned or overridden (for example trigger buttons that force `type="button"`, or custom `size` props on styled controls)
 - `className` and `style` are merged with component styles so you can layer custom styles on top
+- Exception: `Flex` and `Grid` intentionally do not accept inline `style` overrides to keep layout APIs token-driven and consistent.
 
 Example: native event handlers and `aria-*` props are forwarded to form controls.
 
@@ -78,30 +79,19 @@ For contributor-facing implementation details and current edge cases, see:
 - `align`: `'start' | 'end' | 'center' | 'stretch' | 'baseline'` (default: `'stretch'`)
 - `justify`: `'start' | 'end' | 'center' | 'between' | 'around' | 'evenly'` (default: `'start'`)
 - `wrap`: `'nowrap' | 'wrap' | 'wrap-reverse'` (default: `'nowrap'`)
-- `alignContent`: `'start' | 'end' | 'center' | 'stretch' | 'between' | 'around' | 'evenly'` (default: `'stretch'`)
-- `gap` / `rowGap` / `columnGap`: `'xxxs' | 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl'`
+- `gap`: `'xxxs' | 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl'`
 - `padding`: spacing token for all sides
-- `basis`: spacing token (`'sm'`, `'xl'`) or raw CSS `flex-basis` value (`'33%'`, `'16rem'`, `240`)
-- `grow`: CSS `flex-grow` value (`0`, `1`, `2`, ...)
-- `shrink`: CSS `flex-shrink` value (`0`, `1`, ...)
-- `flex`: CSS flex shorthand (`'1 1 22rem'`); overrides `basis`/`grow`/`shrink` when provided
-- Plus all native element props from `React.HTMLAttributes<HTMLElement>`
+- Plus native element props from `React.HTMLAttributes<HTMLElement>` except `style`
 
 ## Grid Props
 
-- `columns`: number (`3` -> `repeat(3, minmax(0, 1fr))`) or raw CSS `grid-template-columns` value
-- `rows`: number (`2` -> `repeat(2, minmax(0, 1fr))`) or raw CSS `grid-template-rows` value
-- `autoRows`: raw CSS `grid-auto-rows` value
-- `autoColumns`: raw CSS `grid-auto-columns` value
-- `areas`: raw CSS `grid-template-areas` value
+- `columns`: `1..12` (`3` -> `repeat(3, minmax(0, 1fr))`)
+- `rows`: `1..12` (`2` -> `repeat(2, minmax(0, 1fr))`)
 - `align`: `'start' | 'end' | 'center' | 'stretch'` (default: `'stretch'`)
 - `justify`: `'start' | 'end' | 'center' | 'stretch'` (default: `'stretch'`)
-- `alignContent`: `'start' | 'end' | 'center' | 'stretch' | 'between' | 'around' | 'evenly'` (default: `'stretch'`)
-- `justifyContent`: `'start' | 'end' | 'center' | 'stretch' | 'between' | 'around' | 'evenly'` (default: `'stretch'`)
-- `autoFlow`: `'row' | 'column' | 'row-dense' | 'column-dense'` (default: `'row'`)
-- `gap` / `rowGap` / `columnGap`: `'xxxs' | 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl'`
+- `gap`: `'xxxs' | 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl'`
 - `padding`: spacing token for all sides
-- Plus all native element props from `React.HTMLAttributes<HTMLElement>`
+- Plus native element props from `React.HTMLAttributes<HTMLElement>` except `style`
 
 ## Components
 
@@ -195,9 +185,7 @@ function App() {
 Keep token scoping only (no app-surface styles):
 
 ```tsx
-<ThemeProvider theme="dark">
-  {/* scoped themed subtree */}
-</ThemeProvider>
+<ThemeProvider theme="dark">{/* scoped themed subtree */}</ThemeProvider>
 ```
 
 Disable only `color-scheme` behavior on `ThemeRoot`:

--- a/src/components/Flex/Flex.stories.tsx
+++ b/src/components/Flex/Flex.stories.tsx
@@ -2,7 +2,6 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { expect, within } from 'storybook/test';
 import { Button } from '../Button/Button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../Card/Card';
-import { Typography } from '../Typography/Typography';
 import { Flex } from './Flex';
 
 const meta = {
@@ -14,7 +13,6 @@ const meta = {
     align: 'stretch',
     justify: 'start',
     wrap: 'nowrap',
-    alignContent: 'stretch',
     gap: 'lg',
     inline: false
   },
@@ -35,39 +33,13 @@ const meta = {
       control: 'select',
       options: ['nowrap', 'wrap', 'wrap-reverse']
     },
-    alignContent: {
-      control: 'select',
-      options: ['start', 'end', 'center', 'stretch', 'between', 'around', 'evenly']
-    },
     gap: {
-      control: 'select',
-      options: ['xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl']
-    },
-    rowGap: {
-      control: 'select',
-      options: ['xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl']
-    },
-    columnGap: {
       control: 'select',
       options: ['xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl']
     },
     padding: {
       control: 'select',
       options: ['xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl']
-    },
-    basis: {
-      control: 'text',
-      description: 'Spacing token or CSS flex-basis value (for example: "md", "33%", "16rem").'
-    },
-    grow: {
-      control: 'number'
-    },
-    shrink: {
-      control: 'number'
-    },
-    flex: {
-      control: 'text',
-      description: 'Optional CSS flex shorthand. When set, it overrides basis/grow/shrink.'
     }
   }
 } satisfies Meta<typeof Flex>;
@@ -103,104 +75,49 @@ export const VerticalCards: Story = {
     padding: 'md'
   },
   render: (args) => (
-    <Flex {...args} style={{ maxWidth: 360 }}>
-      <Card>
-        <CardHeader>
-          <CardTitle>Profile</CardTitle>
-          <CardDescription>Manage account details and identity information.</CardDescription>
-        </CardHeader>
-        <CardContent>Update your display name and avatar.</CardContent>
-      </Card>
-      <Card variant="elevated">
-        <CardHeader>
-          <CardTitle>Notifications</CardTitle>
-          <CardDescription>Control email and push notification cadence.</CardDescription>
-        </CardHeader>
-        <CardContent>Mute noisy events and keep critical alerts.</CardContent>
-      </Card>
-    </Flex>
+    <div style={{ maxWidth: 360 }}>
+      <Flex {...args}>
+        <Card>
+          <CardHeader>
+            <CardTitle>Profile</CardTitle>
+            <CardDescription>Manage account details and identity information.</CardDescription>
+          </CardHeader>
+          <CardContent>Update your display name and avatar.</CardContent>
+        </Card>
+        <Card variant="elevated">
+          <CardHeader>
+            <CardTitle>Notifications</CardTitle>
+            <CardDescription>Control email and push notification cadence.</CardDescription>
+          </CardHeader>
+          <CardContent>Mute noisy events and keep critical alerts.</CardContent>
+        </Card>
+      </Flex>
+    </div>
   )
 };
 
 export const WrappedActions: Story = {
   args: {
     wrap: 'wrap',
-    gap: 'sm',
-    rowGap: 'md',
-    columnGap: 'sm'
+    gap: 'sm'
   },
   render: (args) => (
-    <Flex {...args} style={{ maxWidth: 280 }}>
-      <Button size="sm">New file</Button>
-      <Button size="sm" variant="secondary">
-        Export
-      </Button>
-      <Button size="sm" variant="ghost">
-        Share link
-      </Button>
-      <Button size="sm" variant="secondary">
-        Archive
-      </Button>
-      <Button size="sm" variant="ghost">
-        Delete
-      </Button>
-    </Flex>
-  )
-};
-
-export const BasisSizing: Story = {
-  render: () => (
-    <Flex direction="column" gap="md" style={{ maxWidth: 680 }}>
-      <Typography variant="small">
-        Use basis/grow/shrink for explicit control, or flex shorthand for app-specific sizing.
-      </Typography>
-      <Flex gap="sm">
-        <Flex
-          basis="xl"
-          grow={1}
-          style={{ border: '1px solid #d1d5db', borderRadius: 6, padding: '0.5rem' }}
-        >
-          <Typography variant="small">basis=&quot;xl&quot; grow={'{1}'}</Typography>
-        </Flex>
-        <Flex
-          basis="35%"
-          shrink={0}
-          style={{ border: '1px solid #d1d5db', borderRadius: 6, padding: '0.5rem' }}
-        >
-          <Typography variant="small">basis=&quot;35%&quot; shrink={'{0}'}</Typography>
-        </Flex>
-        <Flex
-          flex="0 0 220px"
-          style={{ border: '1px solid #d1d5db', borderRadius: 6, padding: '0.5rem' }}
-        >
-          <Typography variant="small">flex=&quot;0 0 220px&quot;</Typography>
-        </Flex>
+    <div style={{ maxWidth: 280 }}>
+      <Flex {...args}>
+        <Button size="sm">New file</Button>
+        <Button size="sm" variant="secondary">
+          Export
+        </Button>
+        <Button size="sm" variant="ghost">
+          Share link
+        </Button>
+        <Button size="sm" variant="secondary">
+          Archive
+        </Button>
+        <Button size="sm" variant="ghost">
+          Delete
+        </Button>
       </Flex>
-    </Flex>
-  )
-};
-
-export const WrappedColumns: Story = {
-  render: () => (
-    <Flex
-      wrap="wrap"
-      alignContent="start"
-      gap="sm"
-      rowGap="md"
-      style={{ maxWidth: 620, minHeight: 220 }}
-    >
-      {['Overview', 'Roadmap', 'Quality', 'Notes', 'Releases', 'Owners'].map((label) => (
-        <Flex
-          key={label}
-          flex="1 1 180px"
-          direction="column"
-          gap="xs"
-          style={{ border: '1px solid #d1d5db', borderRadius: 6, padding: '0.5rem' }}
-        >
-          <Typography variant="small">{label}</Typography>
-          <Typography variant="muted">Flexible card columns with controlled wrapping.</Typography>
-        </Flex>
-      ))}
-    </Flex>
+    </div>
   )
 };

--- a/src/components/Flex/Flex.styles.ts
+++ b/src/components/Flex/Flex.styles.ts
@@ -7,14 +7,6 @@ export type FlexDirection = 'row' | 'row-reverse' | 'column' | 'column-reverse';
 export type FlexAlign = 'start' | 'end' | 'center' | 'stretch' | 'baseline';
 export type FlexJustify = 'start' | 'end' | 'center' | 'between' | 'around' | 'evenly';
 export type FlexWrap = 'nowrap' | 'wrap' | 'wrap-reverse';
-export type FlexAlignContent =
-  | 'start'
-  | 'end'
-  | 'center'
-  | 'stretch'
-  | 'between'
-  | 'around'
-  | 'evenly';
 
 const flexGapTokens = {
   xxxs: spacingTokens.xxxs,
@@ -28,31 +20,16 @@ const flexGapTokens = {
 
 export type FlexGap = keyof typeof flexGapTokens;
 export type FlexPadding = keyof typeof flexGapTokens;
-export type FlexBasisToken = keyof typeof flexGapTokens;
-type CSSFlexBasis = NonNullable<CSSProperties['flexBasis']>;
-type CSSFlex = NonNullable<CSSProperties['flex']>;
-export type FlexBasis = FlexBasisToken | CSSFlexBasis;
-export type FlexGrow = number | string;
-export type FlexShrink = number | string;
-export type FlexValue = CSSFlex;
 
 interface GetFlexStylePropsOptions {
   direction: FlexDirection;
   align: FlexAlign;
   justify: FlexJustify;
   wrap: FlexWrap;
-  alignContent: FlexAlignContent;
   inline: boolean;
   gap?: FlexGap;
-  rowGap?: FlexGap;
-  columnGap?: FlexGap;
   padding?: FlexPadding;
-  basis?: FlexBasis;
-  grow?: FlexGrow;
-  shrink?: FlexShrink;
-  flex?: FlexValue;
   className?: string;
-  style?: CSSProperties;
 }
 
 const flexStyles = stylex.create({
@@ -107,27 +84,6 @@ const flexStyles = stylex.create({
   justifyEvenly: {
     justifyContent: 'space-evenly'
   },
-  alignContentStart: {
-    alignContent: 'flex-start'
-  },
-  alignContentEnd: {
-    alignContent: 'flex-end'
-  },
-  alignContentCenter: {
-    alignContent: 'center'
-  },
-  alignContentStretch: {
-    alignContent: 'stretch'
-  },
-  alignContentBetween: {
-    alignContent: 'space-between'
-  },
-  alignContentAround: {
-    alignContent: 'space-around'
-  },
-  alignContentEvenly: {
-    alignContent: 'space-evenly'
-  },
   nowrap: {
     flexWrap: 'nowrap'
   },
@@ -163,39 +119,17 @@ const justifyStyles: Record<FlexJustify, unknown> = {
   evenly: flexStyles.justifyEvenly
 };
 
-const alignContentStyles: Record<FlexAlignContent, unknown> = {
-  start: flexStyles.alignContentStart,
-  end: flexStyles.alignContentEnd,
-  center: flexStyles.alignContentCenter,
-  stretch: flexStyles.alignContentStretch,
-  between: flexStyles.alignContentBetween,
-  around: flexStyles.alignContentAround,
-  evenly: flexStyles.alignContentEvenly
-};
-
 const wrapStyles: Record<FlexWrap, unknown> = {
   nowrap: flexStyles.nowrap,
   wrap: flexStyles.wrap,
   'wrap-reverse': flexStyles.wrapReverse
 };
 
-function getGapStyle({
-  gap,
-  rowGap,
-  columnGap
-}: Pick<GetFlexStylePropsOptions, 'gap' | 'rowGap' | 'columnGap'>): CSSProperties | undefined {
+function getGapStyle({ gap }: Pick<GetFlexStylePropsOptions, 'gap'>): CSSProperties | undefined {
   const gapStyle: CSSProperties = {};
 
   if (gap != null) {
     gapStyle.gap = flexGapTokens[gap];
-  }
-
-  if (rowGap != null) {
-    gapStyle.rowGap = flexGapTokens[rowGap];
-  }
-
-  if (columnGap != null) {
-    gapStyle.columnGap = flexGapTokens[columnGap];
   }
 
   return Object.keys(gapStyle).length > 0 ? gapStyle : undefined;
@@ -212,75 +146,22 @@ function getPaddingStyle({
 
   return Object.keys(paddingStyle).length > 0 ? paddingStyle : undefined;
 }
-
-function isFlexBasisToken(value: FlexBasis): value is FlexBasisToken {
-  return typeof value === 'string' && Object.prototype.hasOwnProperty.call(flexGapTokens, value);
-}
-
-function getBasisStyle({
-  basis
-}: Pick<GetFlexStylePropsOptions, 'basis'>): CSSProperties | undefined {
-  if (basis == null) {
-    return undefined;
-  }
-
-  return {
-    flexBasis: isFlexBasisToken(basis) ? flexGapTokens[basis] : basis
-  };
-}
-
-function getFlexSizingStyle({
-  basis,
-  grow,
-  shrink,
-  flex
-}: Pick<GetFlexStylePropsOptions, 'basis' | 'grow' | 'shrink' | 'flex'>):
-  | CSSProperties
-  | undefined {
-  if (flex != null) {
-    return { flex };
-  }
-
-  const basisStyle = getBasisStyle({ basis });
-  const sizingStyle: CSSProperties = basisStyle != null ? { ...basisStyle } : {};
-
-  if (grow != null) {
-    sizingStyle.flexGrow = grow;
-  }
-
-  if (shrink != null) {
-    sizingStyle.flexShrink = shrink;
-  }
-
-  return Object.keys(sizingStyle).length > 0 ? sizingStyle : undefined;
-}
-
 export function getFlexStyleProps({
   direction,
   align,
   justify,
   wrap,
-  alignContent,
   inline,
   gap,
-  rowGap,
-  columnGap,
   padding,
-  basis,
-  grow,
-  shrink,
-  flex,
-  className,
-  style
+  className
 }: GetFlexStylePropsOptions) {
-  const tokenGapStyle = getGapStyle({ gap, rowGap, columnGap });
+  const tokenGapStyle = getGapStyle({ gap });
   const paddingStyle = getPaddingStyle({ padding });
-  const sizingStyle = getFlexSizingStyle({ basis, grow, shrink, flex });
   const tokenStyle =
-    tokenGapStyle != null || paddingStyle != null || sizingStyle != null
-      ? { ...tokenGapStyle, ...paddingStyle, ...sizingStyle }
+    tokenGapStyle != null || paddingStyle != null
+      ? { ...tokenGapStyle, ...paddingStyle }
       : undefined;
-  const mergedStyle = tokenStyle != null || style != null ? { ...tokenStyle, ...style } : undefined;
 
   return composeStyleProps(
     [
@@ -289,9 +170,8 @@ export function getFlexStyleProps({
       pickStyle(directionStyles, direction),
       pickStyle(alignStyles, align),
       pickStyle(justifyStyles, justify),
-      pickStyle(alignContentStyles, alignContent),
       pickStyle(wrapStyles, wrap)
     ],
-    { className, style: mergedStyle }
+    { className, style: tokenStyle }
   );
 }

--- a/src/components/Flex/Flex.test.tsx
+++ b/src/components/Flex/Flex.test.tsx
@@ -16,16 +16,15 @@ describe('Flex', () => {
     expect(flex).toHaveAttribute('data-direction', 'row');
     expect(flex).toHaveAttribute('data-align', 'stretch');
     expect(flex).toHaveAttribute('data-justify', 'start');
-    expect(flex).toHaveAttribute('data-align-content', 'stretch');
     expect(flex).toHaveAttribute('data-wrap', 'nowrap');
     expect(flex).not.toHaveAttribute('data-inline');
   });
 
-  it('supports token-backed gap, rowGap, and columnGap styles', () => {
-    render(<Flex data-testid="flex" gap="lg" rowGap="md" columnGap="xl" />);
+  it('supports token-backed gap styles', () => {
+    render(<Flex data-testid="flex" gap="lg" />);
 
     const flex = screen.getByTestId('flex');
-    expect(flex).toHaveStyle({ gap: '0.75rem', rowGap: '0.625rem', columnGap: '1rem' });
+    expect(flex).toHaveStyle({ gap: '0.75rem' });
   });
 
   it('supports token-backed padding styles', () => {
@@ -33,46 +32,6 @@ describe('Flex', () => {
 
     const flex = screen.getByTestId('flex');
     expect(flex).toHaveStyle({ padding: '0.5rem' });
-  });
-
-  it('supports token-backed flex-basis styles', () => {
-    render(<Flex data-testid="flex" basis="xl" />);
-
-    const flex = screen.getByTestId('flex');
-    expect(flex).toHaveStyle({ flexBasis: '1rem' });
-  });
-
-  it('supports raw flex-basis values', () => {
-    const { rerender } = render(<Flex data-testid="flex" basis="33%" />);
-    const flex = screen.getByTestId('flex');
-
-    expect(flex).toHaveStyle({ flexBasis: '33%' });
-
-    rerender(<Flex data-testid="flex" basis={240} />);
-    expect(flex).toHaveStyle({ flexBasis: '240px' });
-  });
-
-  it('supports grow and shrink item sizing controls', () => {
-    render(<Flex data-testid="flex" grow={1} shrink={0} />);
-
-    const flex = screen.getByTestId('flex');
-    expect(flex).toHaveStyle({ flexGrow: '1', flexShrink: '0' });
-  });
-
-  it('supports flex shorthand and alignContent', () => {
-    render(<Flex data-testid="flex" flex="1 1 20rem" wrap="wrap" alignContent="between" />);
-
-    const flex = screen.getByTestId('flex');
-    expect(flex).toHaveStyle({ flex: '1 1 20rem' });
-    expect(flex).toHaveAttribute('data-align-content', 'between');
-  });
-
-  it('prefers flex shorthand over basis/grow/shrink when both are passed', () => {
-    render(<Flex data-testid="flex" basis="xl" grow={1} shrink={0} flex="0 0 40%" />);
-
-    const flex = screen.getByTestId('flex');
-    expect(flex).toHaveStyle({ flex: '0 0 40%' });
-    expect(flex).not.toHaveStyle({ flexBasis: '1rem' });
   });
 
   it('updates style composition when direction and wrap change', () => {
@@ -101,21 +60,5 @@ describe('Flex', () => {
     expect(flex.tagName).toBe('SECTION');
     expect(ref.current).toBe(flex);
     expect(flex).toHaveAttribute('data-inline', 'true');
-  });
-
-  it('lets inline style overrides win over token spacing and sizing props', () => {
-    render(
-      <Flex
-        data-testid="flex"
-        gap="sm"
-        padding="sm"
-        basis="xl"
-        grow={1}
-        style={{ gap: '4rem', padding: '2rem', flexBasis: '50%', flexGrow: 3 }}
-      />
-    );
-
-    const flex = screen.getByTestId('flex');
-    expect(flex).toHaveStyle({ gap: '4rem', padding: '2rem', flexBasis: '50%', flexGrow: '3' });
   });
 });

--- a/src/components/Flex/Flex.tsx
+++ b/src/components/Flex/Flex.tsx
@@ -2,15 +2,10 @@ import { createElement, type HTMLAttributes, type Ref } from 'react';
 import {
   getFlexStyleProps,
   type FlexAlign,
-  type FlexAlignContent,
-  type FlexBasis,
   type FlexDirection,
-  type FlexGrow,
   type FlexGap,
   type FlexJustify,
   type FlexPadding,
-  type FlexShrink,
-  type FlexValue,
   type FlexWrap
 } from './Flex.styles';
 
@@ -29,23 +24,16 @@ export type FlexElement =
   | 'span'
   | 'ul';
 
-export interface FlexProps extends HTMLAttributes<HTMLElement> {
+export interface FlexProps extends Omit<HTMLAttributes<HTMLElement>, 'style'> {
   ref?: Ref<HTMLElement>;
   as?: FlexElement;
   direction?: FlexDirection;
   align?: FlexAlign;
   justify?: FlexJustify;
   wrap?: FlexWrap;
-  alignContent?: FlexAlignContent;
   inline?: boolean;
   gap?: FlexGap;
-  rowGap?: FlexGap;
-  columnGap?: FlexGap;
   padding?: FlexPadding;
-  basis?: FlexBasis;
-  grow?: FlexGrow;
-  shrink?: FlexShrink;
-  flex?: FlexValue;
 }
 
 export function Flex({
@@ -55,18 +43,10 @@ export function Flex({
   align = 'stretch',
   justify = 'start',
   wrap = 'nowrap',
-  alignContent = 'stretch',
   inline = false,
   gap,
-  rowGap,
-  columnGap,
   padding,
-  basis,
-  grow,
-  shrink,
-  flex,
   className,
-  style,
   ...props
 }: FlexProps) {
   const styleProps = getFlexStyleProps({
@@ -74,18 +54,10 @@ export function Flex({
     align,
     justify,
     wrap,
-    alignContent,
     inline,
     gap,
-    rowGap,
-    columnGap,
     padding,
-    basis,
-    grow,
-    shrink,
-    flex,
-    className,
-    style
+    className
   });
   const Component = as ?? 'div';
 
@@ -97,21 +69,15 @@ export function Flex({
     'data-direction': direction,
     'data-inline': inline || undefined,
     'data-justify': justify,
-    'data-align-content': alignContent,
     'data-wrap': wrap
   });
 }
 
 export type {
   FlexAlign,
-  FlexAlignContent,
-  FlexBasis,
   FlexDirection,
-  FlexGrow,
   FlexGap,
   FlexJustify,
   FlexPadding,
-  FlexShrink,
-  FlexValue,
   FlexWrap
 } from './Flex.styles';

--- a/src/components/Grid/Grid.stories.tsx
+++ b/src/components/Grid/Grid.stories.tsx
@@ -12,22 +12,17 @@ const meta = {
     columns: 3,
     align: 'stretch',
     justify: 'stretch',
-    alignContent: 'stretch',
-    justifyContent: 'stretch',
-    autoFlow: 'row',
     gap: 'lg',
     inline: false
   },
   argTypes: {
     columns: {
-      control: 'number',
-      description:
-        'Number (maps to repeat(n, minmax(0, 1fr))) or raw CSS grid-template-columns string.'
+      control: 'select',
+      options: [1, 2, 3, 4, 5, 6, 12]
     },
     rows: {
-      control: 'text',
-      description:
-        'Number (maps to repeat(n, minmax(0, 1fr))) or raw CSS grid-template-rows string.'
+      control: 'select',
+      options: [1, 2, 3, 4, 5, 6]
     },
     align: {
       control: 'select',
@@ -37,42 +32,13 @@ const meta = {
       control: 'select',
       options: ['start', 'end', 'center', 'stretch']
     },
-    alignContent: {
-      control: 'select',
-      options: ['start', 'end', 'center', 'stretch', 'between', 'around', 'evenly']
-    },
-    justifyContent: {
-      control: 'select',
-      options: ['start', 'end', 'center', 'stretch', 'between', 'around', 'evenly']
-    },
-    autoFlow: {
-      control: 'select',
-      options: ['row', 'column', 'row-dense', 'column-dense']
-    },
     gap: {
-      control: 'select',
-      options: ['xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl']
-    },
-    rowGap: {
-      control: 'select',
-      options: ['xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl']
-    },
-    columnGap: {
       control: 'select',
       options: ['xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl']
     },
     padding: {
       control: 'select',
       options: ['xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl']
-    },
-    autoRows: {
-      control: 'text'
-    },
-    autoColumns: {
-      control: 'text'
-    },
-    areas: {
-      control: 'text'
     }
   }
 } satisfies Meta<typeof Grid>;
@@ -109,62 +75,68 @@ export const Default: Story = {
     const canvas = within(canvasElement);
     const grid = canvas.getByTestId('grid-default');
 
-    expect(grid).toHaveAttribute('data-auto-flow', 'row');
+    expect(grid).toHaveAttribute('data-align', 'stretch');
     expect(canvas.getByRole('button', { name: 'Profile' })).toBeVisible();
   }
 };
 
 export const DashboardPanels: Story = {
   args: {
-    columns: 'repeat(auto-fit, minmax(13rem, 1fr))',
+    columns: 2,
     gap: 'md',
-    rowGap: 'lg',
     padding: 'sm',
     align: 'stretch'
   },
   render: (args) => (
-    <Grid {...args} style={{ maxWidth: 880 }}>
-      <section style={panelStyle}>
-        <Typography variant="small">Revenue</Typography>
-        <Typography variant="muted">$24,981 this month</Typography>
-      </section>
-      <section style={panelStyle}>
-        <Typography variant="small">Activation</Typography>
-        <Typography variant="muted">63% users completed onboarding</Typography>
-      </section>
-      <section style={panelStyle}>
-        <Typography variant="small">Reliability</Typography>
-        <Typography variant="muted">99.98% service uptime in the last 30 days</Typography>
-      </section>
-      <section style={panelStyle}>
-        <Typography variant="small">Support</Typography>
-        <Typography variant="muted">Median first response: 17 minutes</Typography>
-      </section>
-    </Grid>
+    <div style={{ maxWidth: 880 }}>
+      <Grid {...args}>
+        <section style={panelStyle}>
+          <Typography variant="small">Revenue</Typography>
+          <Typography variant="muted">$24,981 this month</Typography>
+        </section>
+        <section style={panelStyle}>
+          <Typography variant="small">Activation</Typography>
+          <Typography variant="muted">63% users completed onboarding</Typography>
+        </section>
+        <section style={panelStyle}>
+          <Typography variant="small">Reliability</Typography>
+          <Typography variant="muted">99.98% service uptime in the last 30 days</Typography>
+        </section>
+        <section style={panelStyle}>
+          <Typography variant="small">Support</Typography>
+          <Typography variant="muted">Median first response: 17 minutes</Typography>
+        </section>
+      </Grid>
+    </div>
   )
 };
 
-export const TemplateAreas: Story = {
+export const Matrix: Story = {
   args: {
-    columns: '2fr 1fr',
-    rows: 'auto auto',
-    areas: '"hero sidebar" "table sidebar"',
+    columns: 3,
+    rows: 2,
     gap: 'sm'
   },
   render: (args) => (
-    <Grid {...args} style={{ maxWidth: 760 }}>
-      <section style={{ ...panelStyle, gridArea: 'hero' }}>
-        <Typography variant="small">Release Health</Typography>
-        <Typography variant="muted">No production incidents in the last 14 days.</Typography>
+    <Grid {...args}>
+      <section style={panelStyle}>
+        <Typography variant="small">A1</Typography>
       </section>
-      <section style={{ ...panelStyle, gridArea: 'table' }}>
-        <Typography variant="small">Open Work</Typography>
-        <Typography variant="muted">17 tasks pending review in this sprint.</Typography>
+      <section style={panelStyle}>
+        <Typography variant="small">A2</Typography>
       </section>
-      <aside style={{ ...panelStyle, gridArea: 'sidebar' }}>
-        <Typography variant="small">Owners</Typography>
-        <Typography variant="muted">Design, Platform, and QA rotations assigned.</Typography>
-      </aside>
+      <section style={panelStyle}>
+        <Typography variant="small">A3</Typography>
+      </section>
+      <section style={panelStyle}>
+        <Typography variant="small">B1</Typography>
+      </section>
+      <section style={panelStyle}>
+        <Typography variant="small">B2</Typography>
+      </section>
+      <section style={panelStyle}>
+        <Typography variant="small">B3</Typography>
+      </section>
     </Grid>
   )
 };

--- a/src/components/Grid/Grid.styles.ts
+++ b/src/components/Grid/Grid.styles.ts
@@ -5,16 +5,6 @@ import { spacingTokens } from '../../theme/tokens/foundationTokens.stylex';
 
 export type GridAlign = 'start' | 'end' | 'center' | 'stretch';
 export type GridJustify = 'start' | 'end' | 'center' | 'stretch';
-export type GridAlignContent =
-  | 'start'
-  | 'end'
-  | 'center'
-  | 'stretch'
-  | 'between'
-  | 'around'
-  | 'evenly';
-export type GridJustifyContent = GridAlignContent;
-export type GridAutoFlow = 'row' | 'column' | 'row-dense' | 'column-dense';
 
 const gridSpacingTokens = {
   xxxs: spacingTokens.xxxs,
@@ -28,33 +18,19 @@ const gridSpacingTokens = {
 
 export type GridGap = keyof typeof gridSpacingTokens;
 export type GridPadding = keyof typeof gridSpacingTokens;
-type CSSGridTemplateColumns = NonNullable<CSSProperties['gridTemplateColumns']>;
-type CSSGridTemplateRows = NonNullable<CSSProperties['gridTemplateRows']>;
-type CSSGridTrackSize = NonNullable<CSSProperties['gridAutoRows']>;
-type CSSGridAreas = NonNullable<CSSProperties['gridTemplateAreas']>;
-export type GridTemplateColumns = number | CSSGridTemplateColumns;
-export type GridTemplateRows = number | CSSGridTemplateRows;
-export type GridTrackSize = CSSGridTrackSize;
-export type GridAreas = CSSGridAreas;
+export type GridTrackCount = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+export type GridTemplateColumns = GridTrackCount;
+export type GridTemplateRows = GridTrackCount;
 
 interface GetGridStylePropsOptions {
   align: GridAlign;
   justify: GridJustify;
-  alignContent: GridAlignContent;
-  justifyContent: GridJustifyContent;
-  autoFlow: GridAutoFlow;
   inline: boolean;
   columns?: GridTemplateColumns;
   rows?: GridTemplateRows;
-  autoRows?: GridTrackSize;
-  autoColumns?: GridTrackSize;
-  areas?: GridAreas;
   gap?: GridGap;
-  rowGap?: GridGap;
-  columnGap?: GridGap;
   padding?: GridPadding;
   className?: string;
-  style?: CSSProperties;
 }
 
 const gridStyles = stylex.create({
@@ -87,60 +63,6 @@ const gridStyles = stylex.create({
   },
   justifyStretch: {
     justifyItems: 'stretch'
-  },
-  alignContentStart: {
-    alignContent: 'start'
-  },
-  alignContentEnd: {
-    alignContent: 'end'
-  },
-  alignContentCenter: {
-    alignContent: 'center'
-  },
-  alignContentStretch: {
-    alignContent: 'stretch'
-  },
-  alignContentBetween: {
-    alignContent: 'space-between'
-  },
-  alignContentAround: {
-    alignContent: 'space-around'
-  },
-  alignContentEvenly: {
-    alignContent: 'space-evenly'
-  },
-  justifyContentStart: {
-    justifyContent: 'start'
-  },
-  justifyContentEnd: {
-    justifyContent: 'end'
-  },
-  justifyContentCenter: {
-    justifyContent: 'center'
-  },
-  justifyContentStretch: {
-    justifyContent: 'stretch'
-  },
-  justifyContentBetween: {
-    justifyContent: 'space-between'
-  },
-  justifyContentAround: {
-    justifyContent: 'space-around'
-  },
-  justifyContentEvenly: {
-    justifyContent: 'space-evenly'
-  },
-  autoFlowRow: {
-    gridAutoFlow: 'row'
-  },
-  autoFlowColumn: {
-    gridAutoFlow: 'column'
-  },
-  autoFlowRowDense: {
-    gridAutoFlow: 'row dense'
-  },
-  autoFlowColumnDense: {
-    gridAutoFlow: 'column dense'
   }
 });
 
@@ -158,50 +80,11 @@ const justifyStyles: Record<GridJustify, unknown> = {
   stretch: gridStyles.justifyStretch
 };
 
-const alignContentStyles: Record<GridAlignContent, unknown> = {
-  start: gridStyles.alignContentStart,
-  end: gridStyles.alignContentEnd,
-  center: gridStyles.alignContentCenter,
-  stretch: gridStyles.alignContentStretch,
-  between: gridStyles.alignContentBetween,
-  around: gridStyles.alignContentAround,
-  evenly: gridStyles.alignContentEvenly
-};
-
-const justifyContentStyles: Record<GridJustifyContent, unknown> = {
-  start: gridStyles.justifyContentStart,
-  end: gridStyles.justifyContentEnd,
-  center: gridStyles.justifyContentCenter,
-  stretch: gridStyles.justifyContentStretch,
-  between: gridStyles.justifyContentBetween,
-  around: gridStyles.justifyContentAround,
-  evenly: gridStyles.justifyContentEvenly
-};
-
-const autoFlowStyles: Record<GridAutoFlow, unknown> = {
-  row: gridStyles.autoFlowRow,
-  column: gridStyles.autoFlowColumn,
-  'row-dense': gridStyles.autoFlowRowDense,
-  'column-dense': gridStyles.autoFlowColumnDense
-};
-
-function getGapStyle({
-  gap,
-  rowGap,
-  columnGap
-}: Pick<GetGridStylePropsOptions, 'gap' | 'rowGap' | 'columnGap'>): CSSProperties | undefined {
+function getGapStyle({ gap }: Pick<GetGridStylePropsOptions, 'gap'>): CSSProperties | undefined {
   const gapStyle: CSSProperties = {};
 
   if (gap != null) {
     gapStyle.gap = gridSpacingTokens[gap];
-  }
-
-  if (rowGap != null) {
-    gapStyle.rowGap = gridSpacingTokens[rowGap];
-  }
-
-  if (columnGap != null) {
-    gapStyle.columnGap = gridSpacingTokens[columnGap];
   }
 
   return Object.keys(gapStyle).length > 0 ? gapStyle : undefined;
@@ -220,23 +103,13 @@ function getPaddingStyle({
 }
 
 function resolveTemplate(template: GridTemplateColumns | GridTemplateRows): string {
-  if (typeof template === 'number') {
-    const trackCount = Number.isFinite(template) ? Math.max(1, Math.floor(template)) : 1;
-    return `repeat(${trackCount}, minmax(0, 1fr))`;
-  }
-
-  return String(template);
+  return `repeat(${template}, minmax(0, 1fr))`;
 }
 
 function getTemplateStyle({
   columns,
-  rows,
-  autoRows,
-  autoColumns,
-  areas
-}: Pick<GetGridStylePropsOptions, 'columns' | 'rows' | 'autoRows' | 'autoColumns' | 'areas'>):
-  | CSSProperties
-  | undefined {
+  rows
+}: Pick<GetGridStylePropsOptions, 'columns' | 'rows'>): CSSProperties | undefined {
   const templateStyle: CSSProperties = {};
 
   if (columns != null) {
@@ -247,59 +120,34 @@ function getTemplateStyle({
     templateStyle.gridTemplateRows = resolveTemplate(rows);
   }
 
-  if (autoRows != null) {
-    templateStyle.gridAutoRows = autoRows;
-  }
-
-  if (autoColumns != null) {
-    templateStyle.gridAutoColumns = autoColumns;
-  }
-
-  if (areas != null) {
-    templateStyle.gridTemplateAreas = areas;
-  }
-
   return Object.keys(templateStyle).length > 0 ? templateStyle : undefined;
 }
 
 export function getGridStyleProps({
   align,
   justify,
-  alignContent,
-  justifyContent,
-  autoFlow,
   inline,
   columns,
   rows,
-  autoRows,
-  autoColumns,
-  areas,
   gap,
-  rowGap,
-  columnGap,
   padding,
-  className,
-  style
+  className
 }: GetGridStylePropsOptions) {
-  const tokenGapStyle = getGapStyle({ gap, rowGap, columnGap });
+  const tokenGapStyle = getGapStyle({ gap });
   const paddingStyle = getPaddingStyle({ padding });
-  const templateStyle = getTemplateStyle({ columns, rows, autoRows, autoColumns, areas });
+  const templateStyle = getTemplateStyle({ columns, rows });
   const tokenStyle =
     tokenGapStyle != null || paddingStyle != null || templateStyle != null
       ? { ...tokenGapStyle, ...paddingStyle, ...templateStyle }
       : undefined;
-  const mergedStyle = tokenStyle != null || style != null ? { ...tokenStyle, ...style } : undefined;
 
   return composeStyleProps(
     [
       gridStyles.root,
       inline ? gridStyles.inline : null,
       pickStyle(alignStyles, align),
-      pickStyle(justifyStyles, justify),
-      pickStyle(alignContentStyles, alignContent),
-      pickStyle(justifyContentStyles, justifyContent),
-      pickStyle(autoFlowStyles, autoFlow)
+      pickStyle(justifyStyles, justify)
     ],
-    { className, style: mergedStyle }
+    { className, style: tokenStyle }
   );
 }

--- a/src/components/Grid/Grid.test.tsx
+++ b/src/components/Grid/Grid.test.tsx
@@ -15,17 +15,14 @@ describe('Grid', () => {
     expect(grid.tagName).toBe('DIV');
     expect(grid).toHaveAttribute('data-align', 'stretch');
     expect(grid).toHaveAttribute('data-justify', 'stretch');
-    expect(grid).toHaveAttribute('data-align-content', 'stretch');
-    expect(grid).toHaveAttribute('data-justify-content', 'stretch');
-    expect(grid).toHaveAttribute('data-auto-flow', 'row');
     expect(grid).not.toHaveAttribute('data-inline');
   });
 
-  it('supports token-backed gap, rowGap, and columnGap styles', () => {
-    render(<Grid data-testid="grid" gap="lg" rowGap="md" columnGap="xl" />);
+  it('supports token-backed gap styles', () => {
+    render(<Grid data-testid="grid" gap="lg" />);
 
     const grid = screen.getByTestId('grid');
-    expect(grid).toHaveStyle({ gap: '0.75rem', rowGap: '0.625rem', columnGap: '1rem' });
+    expect(grid).toHaveStyle({ gap: '0.75rem' });
   });
 
   it('supports token-backed padding styles', () => {
@@ -45,42 +42,17 @@ describe('Grid', () => {
     });
   });
 
-  it('supports raw template and auto track values', () => {
-    render(
-      <Grid
-        data-testid="grid"
-        columns="2fr 1fr"
-        rows="auto auto"
-        autoRows="minmax(4rem, auto)"
-        autoColumns="12rem"
-        areas='"hero side" "table side"'
-      />
-    );
-
-    const grid = screen.getByTestId('grid');
-    expect(grid).toHaveStyle({
-      gridTemplateColumns: '2fr 1fr',
-      gridTemplateRows: 'auto auto',
-      gridAutoRows: 'minmax(4rem, auto)',
-      gridAutoColumns: '12rem',
-      gridTemplateAreas: '"hero side" "table side"'
-    });
-  });
-
-  it('updates class composition when alignment and autoFlow change', () => {
-    const { rerender } = render(
-      <Grid data-testid="grid" align="stretch" justify="stretch" autoFlow="row" />
-    );
+  it('updates class composition when alignment changes', () => {
+    const { rerender } = render(<Grid data-testid="grid" align="stretch" justify="stretch" />);
 
     const grid = screen.getByTestId('grid');
     const baseClassName = grid.className;
 
-    rerender(<Grid data-testid="grid" align="center" justify="end" autoFlow="column-dense" />);
+    rerender(<Grid data-testid="grid" align="center" justify="end" />);
 
     expect(grid.className).not.toEqual(baseClassName);
     expect(grid).toHaveAttribute('data-align', 'center');
     expect(grid).toHaveAttribute('data-justify', 'end');
-    expect(grid).toHaveAttribute('data-auto-flow', 'column-dense');
   });
 
   it('supports semantic element overrides and ref passthrough', () => {
@@ -96,24 +68,5 @@ describe('Grid', () => {
     expect(grid.tagName).toBe('SECTION');
     expect(ref.current).toBe(grid);
     expect(grid).toHaveAttribute('data-inline', 'true');
-  });
-
-  it('lets inline style overrides win over token spacing and templates', () => {
-    render(
-      <Grid
-        data-testid="grid"
-        columns={3}
-        gap="sm"
-        padding="sm"
-        style={{ gridTemplateColumns: 'repeat(6, 1fr)', gap: '3rem', padding: '2rem' }}
-      />
-    );
-
-    const grid = screen.getByTestId('grid');
-    expect(grid).toHaveStyle({
-      gridTemplateColumns: 'repeat(6, 1fr)',
-      gap: '3rem',
-      padding: '2rem'
-    });
   });
 });

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -2,16 +2,11 @@ import { createElement, type HTMLAttributes, type Ref } from 'react';
 import {
   getGridStyleProps,
   type GridAlign,
-  type GridAlignContent,
-  type GridAreas,
-  type GridAutoFlow,
   type GridGap,
   type GridJustify,
-  type GridJustifyContent,
   type GridPadding,
   type GridTemplateColumns,
-  type GridTemplateRows,
-  type GridTrackSize
+  type GridTemplateRows
 } from './Grid.styles';
 
 export type GridElement =
@@ -29,23 +24,15 @@ export type GridElement =
   | 'span'
   | 'ul';
 
-export interface GridProps extends HTMLAttributes<HTMLElement> {
+export interface GridProps extends Omit<HTMLAttributes<HTMLElement>, 'style'> {
   ref?: Ref<HTMLElement>;
   as?: GridElement;
   columns?: GridTemplateColumns;
   rows?: GridTemplateRows;
-  autoRows?: GridTrackSize;
-  autoColumns?: GridTrackSize;
-  areas?: GridAreas;
   align?: GridAlign;
   justify?: GridJustify;
-  alignContent?: GridAlignContent;
-  justifyContent?: GridJustifyContent;
-  autoFlow?: GridAutoFlow;
   inline?: boolean;
   gap?: GridGap;
-  rowGap?: GridGap;
-  columnGap?: GridGap;
   padding?: GridPadding;
 }
 
@@ -54,41 +41,23 @@ export function Grid({
   as,
   columns,
   rows,
-  autoRows,
-  autoColumns,
-  areas,
   align = 'stretch',
   justify = 'stretch',
-  alignContent = 'stretch',
-  justifyContent = 'stretch',
-  autoFlow = 'row',
   inline = false,
   gap,
-  rowGap,
-  columnGap,
   padding,
   className,
-  style,
   ...props
 }: GridProps) {
   const styleProps = getGridStyleProps({
     columns,
     rows,
-    autoRows,
-    autoColumns,
-    areas,
     align,
     justify,
-    alignContent,
-    justifyContent,
-    autoFlow,
     inline,
     gap,
-    rowGap,
-    columnGap,
     padding,
-    className,
-    style
+    className
   });
   const Component = as ?? 'div';
 
@@ -98,23 +67,16 @@ export function Grid({
     ref,
     'data-align': align,
     'data-justify': justify,
-    'data-align-content': alignContent,
-    'data-justify-content': justifyContent,
-    'data-auto-flow': autoFlow,
     'data-inline': inline || undefined
   });
 }
 
 export type {
   GridAlign,
-  GridAlignContent,
-  GridAreas,
-  GridAutoFlow,
   GridGap,
   GridJustify,
-  GridJustifyContent,
   GridPadding,
+  GridTrackCount,
   GridTemplateColumns,
-  GridTemplateRows,
-  GridTrackSize
+  GridTemplateRows
 } from './Grid.styles';

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,34 +111,25 @@ export type {
 export { Flex } from './components/Flex/Flex';
 export type {
   FlexAlign,
-  FlexAlignContent,
-  FlexBasis,
   FlexDirection,
   FlexElement,
-  FlexGrow,
   FlexGap,
   FlexJustify,
   FlexPadding,
   FlexProps,
-  FlexShrink,
-  FlexValue,
   FlexWrap
 } from './components/Flex/Flex';
 export { Grid } from './components/Grid/Grid';
 export type {
   GridAlign,
-  GridAlignContent,
-  GridAreas,
-  GridAutoFlow,
   GridElement,
   GridGap,
   GridJustify,
-  GridJustifyContent,
   GridPadding,
   GridProps,
+  GridTrackCount,
   GridTemplateColumns,
-  GridTemplateRows,
-  GridTrackSize
+  GridTemplateRows
 } from './components/Grid/Grid';
 export { HoverCard, HoverCardContent, HoverCardTrigger } from './components/HoverCard/HoverCard';
 export type {

--- a/src/theme/DesignSystemOverview.stories.tsx
+++ b/src/theme/DesignSystemOverview.stories.tsx
@@ -946,12 +946,7 @@ function getMemberStatusBadgeVariant(status: string): 'success' | 'warning' {
 
 function ComponentSamplePage() {
   return (
-    <Flex
-      as="main"
-      direction="column"
-      gap="xl"
-      style={{ margin: '0 auto', maxWidth: 1080, paddingBottom: spacingTokens.xl }}
-    >
+    <Flex as="main" direction="column" gap="xl" padding="xl">
       <Flex as="header" direction="column" gap="md">
         <Breadcrumb aria-label="Workspace path">
           <BreadcrumbList>
@@ -969,7 +964,7 @@ function ComponentSamplePage() {
           </BreadcrumbList>
         </Breadcrumb>
 
-        <Flex align="start" justify="between" wrap="wrap" rowGap="sm" columnGap="md">
+        <Flex align="start" justify="between" wrap="wrap" gap="md">
           <Flex direction="column" gap="xxs">
             <Typography as="h1" variant="h2">
               Release Command Center
@@ -1091,22 +1086,13 @@ function ComponentSamplePage() {
                 <CardDescription>Gate review before final publish.</CardDescription>
               </CardHeader>
               <CardContent>
-                <Flex
-                  as="ul"
-                  direction="column"
-                  gap="sm"
-                  style={{ listStyle: 'none', margin: 0, padding: 0 }}
-                >
-                  <li>
+                <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+                  <Flex as="li" direction="column" gap="sm">
                     <Typography>QA regression passed in staging.</Typography>
-                  </li>
-                  <li>
                     <Typography>Accessibility spot checks completed.</Typography>
-                  </li>
-                  <li>
                     <Typography>Rollback plan approved by on-call.</Typography>
-                  </li>
-                </Flex>
+                  </Flex>
+                </ul>
               </CardContent>
               <CardFooter>
                 <Button size="sm" variant="ghost">


### PR DESCRIPTION
## Summary
- reduce Flex and Grid to a thin, token-driven layout contract
- remove permissive styling/sizing props and inline style escapes from both components
- align stories, tests, exports, and README docs with the stricter API

## Validation
- pnpm lint
- pnpm test
- pnpm build