### PR TITLE
♻️ refactor(tokens): simplify the low-end spacing scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ For contributor-facing implementation details and current edge cases, see:
 - `align`: `'start' | 'end' | 'center' | 'stretch' | 'baseline'` (default: `'stretch'`)
 - `justify`: `'start' | 'end' | 'center' | 'between' | 'around' | 'evenly'` (default: `'start'`)
 - `wrap`: `'nowrap' | 'wrap' | 'wrap-reverse'` (default: `'nowrap'`)
-- `gap`: `'xxxs' | 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl'`
+- `gap`: `'xs' | 'sm' | 'md' | 'lg' | 'xl'`
 - `padding`: spacing token for all sides
 - Plus native element props from `React.HTMLAttributes<HTMLElement>` except `style`
 
@@ -89,7 +89,7 @@ For contributor-facing implementation details and current edge cases, see:
 - `rows`: `1..12` (`2` -> `repeat(2, minmax(0, 1fr))`)
 - `align`: `'start' | 'end' | 'center' | 'stretch'` (default: `'stretch'`)
 - `justify`: `'start' | 'end' | 'center' | 'stretch'` (default: `'stretch'`)
-- `gap`: `'xxxs' | 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl'`
+- `gap`: `'xs' | 'sm' | 'md' | 'lg' | 'xl'`
 - `padding`: spacing token for all sides
 - Plus native element props from `React.HTMLAttributes<HTMLElement>` except `style`
 

--- a/src/components/Badge/Badge.styles.ts
+++ b/src/components/Badge/Badge.styles.ts
@@ -64,7 +64,7 @@ const badgeStyles = stylex.create({
   sm: {
     fontSize: typographyTokens.fontSizeSm,
     minHeight: spacingTokens.xl,
-    padding: `${spacingTokens.xxs} ${spacingTokens.md}`
+    padding: `${spacingTokens.xs} ${spacingTokens.md}`
   },
   md: {
     fontSize: typographyTokens.fontSizeMd,

--- a/src/components/Combobox/Combobox.styles.ts
+++ b/src/components/Combobox/Combobox.styles.ts
@@ -57,9 +57,9 @@ const comboboxStyles = stylex.create({
   optionFocusVisible: {
     ':focus-visible': {
       outlineColor: borderTokens.focus,
-      outlineOffset: spacingTokens.xxxs,
+      outlineOffset: spacingTokens.xs,
       outlineStyle: 'solid',
-      outlineWidth: spacingTokens.xxxs
+      outlineWidth: spacingTokens.xs
     }
   },
   optionActive: {

--- a/src/components/Empty/Empty.styles.ts
+++ b/src/components/Empty/Empty.styles.ts
@@ -32,7 +32,7 @@ const emptyStyles = stylex.create({
   },
   header: {
     display: 'grid',
-    gap: spacingTokens.xxs,
+    gap: spacingTokens.xs,
     justifyItems: 'inherit',
     maxWidth: '34rem'
   },

--- a/src/components/Flex/Flex.stories.tsx
+++ b/src/components/Flex/Flex.stories.tsx
@@ -35,11 +35,11 @@ const meta = {
     },
     gap: {
       control: 'select',
-      options: ['xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl']
+      options: ['xs', 'sm', 'md', 'lg', 'xl']
     },
     padding: {
       control: 'select',
-      options: ['xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl']
+      options: ['xs', 'sm', 'md', 'lg', 'xl']
     }
   }
 } satisfies Meta<typeof Flex>;

--- a/src/components/Flex/Flex.styles.ts
+++ b/src/components/Flex/Flex.styles.ts
@@ -9,8 +9,6 @@ export type FlexJustify = 'start' | 'end' | 'center' | 'between' | 'around' | 'e
 export type FlexWrap = 'nowrap' | 'wrap' | 'wrap-reverse';
 
 const flexGapTokens = {
-  xxxs: spacingTokens.xxxs,
-  xxs: spacingTokens.xxs,
   xs: spacingTokens.xs,
   sm: spacingTokens.sm,
   md: spacingTokens.md,

--- a/src/components/Grid/Grid.stories.tsx
+++ b/src/components/Grid/Grid.stories.tsx
@@ -34,11 +34,11 @@ const meta = {
     },
     gap: {
       control: 'select',
-      options: ['xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl']
+      options: ['xs', 'sm', 'md', 'lg', 'xl']
     },
     padding: {
       control: 'select',
-      options: ['xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl']
+      options: ['xs', 'sm', 'md', 'lg', 'xl']
     }
   }
 } satisfies Meta<typeof Grid>;

--- a/src/components/Grid/Grid.styles.ts
+++ b/src/components/Grid/Grid.styles.ts
@@ -7,8 +7,6 @@ export type GridAlign = 'start' | 'end' | 'center' | 'stretch';
 export type GridJustify = 'start' | 'end' | 'center' | 'stretch';
 
 const gridSpacingTokens = {
-  xxxs: spacingTokens.xxxs,
-  xxs: spacingTokens.xxs,
   xs: spacingTokens.xs,
   sm: spacingTokens.sm,
   md: spacingTokens.md,

--- a/src/components/Input/Input.styles.ts
+++ b/src/components/Input/Input.styles.ts
@@ -17,7 +17,7 @@ const inputStyles = stylex.create({
   sm: {
     fontSize: typographyTokens.fontSizeSm,
     minHeight: componentSizeTokens.sizeMd,
-    padding: `${spacingTokens.xxs} ${spacingTokens.sm}`
+    padding: `${spacingTokens.xs} ${spacingTokens.sm}`
   },
   md: {
     fontSize: typographyTokens.fontSizeMd,

--- a/src/components/Menubar/Menubar.styles.ts
+++ b/src/components/Menubar/Menubar.styles.ts
@@ -16,7 +16,7 @@ const menubarStyles = stylex.create({
     borderRadius: radiusTokens.md,
     display: 'inline-flex',
     gap: 0,
-    padding: spacingTokens.xxs
+    padding: spacingTokens.xs
   },
   trigger: {
     backgroundColor: 'transparent',

--- a/src/components/ScrollArea/ScrollArea.styles.ts
+++ b/src/components/ScrollArea/ScrollArea.styles.ts
@@ -31,19 +31,19 @@ const scrollAreaStyles = stylex.create({
   },
   scrollbarVertical: {
     width: spacingTokens.md,
-    padding: spacingTokens.xxxs,
+    padding: spacingTokens.xs,
     position: 'absolute',
-    right: spacingTokens.xxxs,
-    top: spacingTokens.xxxs,
-    bottom: spacingTokens.xxxs
+    right: spacingTokens.xs,
+    top: spacingTokens.xs,
+    bottom: spacingTokens.xs
   },
   scrollbarHorizontal: {
     height: spacingTokens.md,
-    padding: spacingTokens.xxxs,
+    padding: spacingTokens.xs,
     position: 'absolute',
-    left: spacingTokens.xxxs,
-    right: spacingTokens.xxxs,
-    bottom: spacingTokens.xxxs
+    left: spacingTokens.xs,
+    right: spacingTokens.xs,
+    bottom: spacingTokens.xs
   },
   thumb: {
     backgroundColor: surfaceTokens.softStrong,

--- a/src/components/ScrollArea/ScrollArea.styles.ts
+++ b/src/components/ScrollArea/ScrollArea.styles.ts
@@ -40,11 +40,11 @@ const scrollAreaStyles = stylex.create({
   },
   scrollbarVertical: {
     width: spacingTokens.sm,
-    padding: spacingTokens.xxxs
+    padding: spacingTokens.xs
   },
   scrollbarHorizontal: {
     height: spacingTokens.sm,
-    padding: spacingTokens.xxxs
+    padding: spacingTokens.xs
   },
   thumb: {
     backgroundColor: surfaceTokens.softStrong,

--- a/src/components/Select/Select.styles.ts
+++ b/src/components/Select/Select.styles.ts
@@ -35,9 +35,9 @@ const selectStyles = stylex.create({
   sm: {
     fontSize: typographyTokens.fontSizeSm,
     minHeight: componentSizeTokens.sizeMd,
-    paddingBottom: spacingTokens.xxs,
+    paddingBottom: spacingTokens.xs,
     paddingLeft: spacingTokens.sm,
-    paddingTop: spacingTokens.xxs
+    paddingTop: spacingTokens.xs
   },
   md: {
     fontSize: typographyTokens.fontSizeMd,

--- a/src/components/Switch/Switch.styles.ts
+++ b/src/components/Switch/Switch.styles.ts
@@ -38,7 +38,7 @@ const switchStyles = stylex.create({
     display: 'inline-flex',
     margin: 0,
     overflow: 'hidden',
-    padding: spacingTokens.xxxs,
+    padding: spacingTokens.xs,
     position: 'relative'
   },
   checked: {

--- a/src/components/Tabs/Tabs.styles.ts
+++ b/src/components/Tabs/Tabs.styles.ts
@@ -12,8 +12,8 @@ const tabsStyles = stylex.create({
   },
   list: {
     display: 'inline-flex',
-    gap: spacingTokens.xxs,
-    padding: spacingTokens.xxs
+    gap: spacingTokens.xs,
+    padding: spacingTokens.xs
   },
   listVertical: {
     alignItems: 'stretch',

--- a/src/components/Toast/Toast.styles.ts
+++ b/src/components/Toast/Toast.styles.ts
@@ -108,7 +108,7 @@ export function getSonnerButtonStyles() {
       color: colorTokens.accentForeground,
       fontFamily: typographyTokens.fontFamily,
       fontWeight: typographyTokens.fontWeightMedium,
-      padding: `${spacingTokens.xxs} ${spacingTokens.sm}`
+      padding: `${spacingTokens.xs} ${spacingTokens.sm}`
     },
     cancel: {
       background: surfaceTokens.soft,
@@ -116,7 +116,7 @@ export function getSonnerButtonStyles() {
       color: colorTokens.foreground,
       fontFamily: typographyTokens.fontFamily,
       fontWeight: typographyTokens.fontWeightMedium,
-      padding: `${spacingTokens.xxs} ${spacingTokens.sm}`
+      padding: `${spacingTokens.xs} ${spacingTokens.sm}`
     },
     close: {
       background: surfaceTokens.elevated,

--- a/src/components/Typography/Typography.styles.ts
+++ b/src/components/Typography/Typography.styles.ts
@@ -82,7 +82,7 @@ const typographyStyles = stylex.create({
     borderRadius: radiusTokens.sm,
     fontFamily: typographyTokens.fontFamilyMono,
     fontSize: typographyTokens.fontSizeSm,
-    padding: `${spacingTokens.xxxs} ${spacingTokens.xs}`
+    padding: `${spacingTokens.xs} ${spacingTokens.xs}`
   },
   blockquote: {
     borderLeftColor: borderTokens.strong,

--- a/src/styles/buttonLike.ts
+++ b/src/styles/buttonLike.ts
@@ -48,9 +48,9 @@ const buttonLikeStyles = stylex.create({
   focusVisibleMenuitemSafe: {
     ':focus-visible:not([role="menuitem"])': {
       outlineColor: borderTokens.focus,
-      outlineOffset: spacingTokens.xxxs,
+      outlineOffset: spacingTokens.xs,
       outlineStyle: 'solid',
-      outlineWidth: spacingTokens.xxxs
+      outlineWidth: spacingTokens.xs
     }
   },
   disabled: {
@@ -109,7 +109,7 @@ const buttonLikeStyles = stylex.create({
   sm: {
     fontSize: typographyTokens.fontSizeSm,
     minHeight: componentSizeTokens.sizeMd,
-    padding: `${spacingTokens.xxs} ${spacingTokens.sm}`
+    padding: `${spacingTokens.xs} ${spacingTokens.sm}`
   },
   md: {
     fontSize: typographyTokens.fontSizeMd,

--- a/src/styles/menu.ts
+++ b/src/styles/menu.ts
@@ -14,7 +14,7 @@ const menuStyles = stylex.create({
     gap: 0,
     minWidth: componentSizeTokens.menuMinWidth,
     overflow: 'hidden',
-    padding: `${spacingTokens.xxs} 0`
+    padding: `${spacingTokens.xs} 0`
   },
   item: {
     appearance: 'none',

--- a/src/styles/primitives.ts
+++ b/src/styles/primitives.ts
@@ -13,9 +13,9 @@ import { borderTokens, colorTokens, controlTokens } from '../theme/tokens/semant
 const focusVisibleOutline = {
   ':focus-visible': {
     outlineColor: borderTokens.focus,
-    outlineOffset: spacingTokens.xxxs,
+    outlineOffset: spacingTokens.xs,
     outlineStyle: 'solid',
-    outlineWidth: spacingTokens.xxxs
+    outlineWidth: spacingTokens.xs
   }
 } as const;
 

--- a/src/theme/DesignSystemOverview.stories.tsx
+++ b/src/theme/DesignSystemOverview.stories.tsx
@@ -965,7 +965,7 @@ function ComponentSamplePage() {
         </Breadcrumb>
 
         <Flex align="start" justify="between" wrap="wrap" gap="md">
-          <Flex direction="column" gap="xxs">
+          <Flex direction="column" gap="xs">
             <Typography as="h1" variant="h2">
               Release Command Center
             </Typography>

--- a/src/theme/tokens/foundationTokens.stylex.ts
+++ b/src/theme/tokens/foundationTokens.stylex.ts
@@ -32,8 +32,6 @@ export const radiusTokens = stylex.defineConsts({
 
 /** Primary spacing scale used for layout gaps, padding, and compact control heights. */
 export const spacingTokens = stylex.defineConsts({
-  xxxs: '0.125rem',
-  xxs: '0.25rem',
   xs: '0.375rem',
   sm: '0.5rem',
   md: '0.625rem',


### PR DESCRIPTION
## Problem

The spacing scale may have more granularity at the smallest sizes than the library meaningfully needs. Extra low-end token choices increase API surface area and make component spacing decisions harder to standardize.

## Why now

Spacing tokens are a cross-cutting public contract. If the smallest part of the scale is noisier than it is useful, that complexity spreads into layout props, stories, docs, and internal component decisions.

## Constraints

- Preserve a coherent public spacing API.
- Make the migration path clear for internal usages and any documented examples.
- Avoid changing the token scale without a clear simplification benefit.

## Desired outcome

- The smallest spacing options are easier to reason about.
- Components and docs rely on a more intentional spacing scale.

## Non-goals

- Redesigning the entire token system.
- Changing spacing semantics beyond what is needed to simplify the low end of the scale.

## Acceptance checks

- [ ] The low-end spacing scale is simplified or otherwise explicitly justified.
- [ ] Internal usages, stories, and docs are updated to match the result.
- [ ] Layout APIs remain clear after the change.
- [ ] `pnpm lint`, `pnpm test`, and `pnpm build` pass.