### PR TITLE
🧹 chore(agents): make repo guidance shorter and task-specific

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,89 +2,43 @@
 
 React 19 + TypeScript component library (Vite, Vitest, Storybook, `pnpm@9.15.2`).
 
-## Rules
+## Always-On Policy
 
 - Build styled, production-ready components first; keep APIs composable.
-- Split behavior/styling when complexity grows.
-- Prefer shared tokens (`spacingTokens`) over raw sizes; no `calc(...)` sizing.
-- Use function components, named exports, explicit `Props`.
-- React 19 `ref` prop pattern only; no `React.forwardRef`.
-- Prefer narrow unions + destructured defaults; no `defaultProps`.
+- Prefer shared tokens (`spacingTokens`) over raw sizes; do not use `calc(...)` sizing.
+- Use function components, named exports, explicit `Props`, and React 19 `ref` prop pattern only.
+- Prefer narrow unions + destructured defaults; do not use `defaultProps`.
 - Prefer `Typography` for user-visible text.
-- Component files: `src/components/<ComponentName>/` with `.tsx`, `.css`, `.stories.tsx`, `.test.tsx`.
+- Keep component files under `src/components/<ComponentName>/` with `.tsx`, `.css`, `.stories.tsx`, `.test.tsx`.
 - Export public API from `src/index.ts`.
+- Use native `gh` CLI only for GitHub operations.
+- Do not commit or hand-edit `dist/`.
 
-## Commands
+## Script Source Of Truth
+
+Use only scripts that exist in `package.json`:
 
 - Install: `pnpm install`
-- Done gate: `pnpm lint`, `pnpm test`, `pnpm build`
-- Common: `pnpm storybook`, `pnpm test:watch`, `pnpm typecheck`, `pnpm format`, `pnpm format:check`, `pnpm lint:fix`, `pnpm build-storybook`
-- Release publish (npm + tag + GitHub): `pnpm release:publish` (pass npm 2FA with `pnpm release:publish -- --otp <code>`)
-- Publish (npm only/manual): `npm publish` (pass `--otp <code>` when npm 2FA requires it)
-- Publish dry-run: `npm publish --dry-run`
+- Done gate: `pnpm check:quality`
+- Pre-push gate: `pnpm check:prepush`
+- Core: `pnpm lint`, `pnpm test`, `pnpm build`, `pnpm typecheck`
+- Formatting: `pnpm format`, `pnpm format:check`, `pnpm lint:fix`
+- Storybook: `pnpm storybook`, `pnpm storybook:port`, `pnpm storybook:ports`, `pnpm build-storybook`
+- Storybook tests: `pnpm test-storybook`, `pnpm test-storybook:coverage`, `pnpm test-storybook:watch`
+- Unit test watch: `pnpm test:watch`
+- Release: `pnpm release:publish` (use `pnpm release:publish -- --otp <code>` for npm 2FA)
 
-## GitHub / Commits
+## Skill Playbooks
 
-- Use native `gh` CLI only (`gh auth login` if needed); no wrappers.
-- Keep issues small; use issues as backlog.
-- Issue/commit format: `<emoji> <type>(<scope>): <summary>`.
-- Issue body: change + acceptance checks.
-- Types: `✨ feat`, `🐛 fix`, `🧹 chore`, `♻️ refactor`, `📝 docs`, `✅ test`, `🎨 style`, `⚡ perf`, `♿ a11y`, `👷 ci`, `🔧 build`.
-- Labels: `type: <emoji> <kind>`; update with `gh label create ... --force`.
-- Flow: `gh issue view` -> implement -> validate -> commit (`Closes #123` / `Fixes #123` when completed; `Refs #123` otherwise) -> push branch -> create PR with `gh pr create` -> merge -> `gh issue close` only if auto-close did not trigger.
-- Default delivery path: create a branch, push it, and create a PR for every change; do not push directly to `main`.
-- When asked to "commit and push", treat it as "commit, push, and open a PR" unless the user explicitly says not to create a PR.
-- Optional: `gh issue develop <number> --checkout`.
-- Commits: atomic, imperative subject (<72 chars), 1-3 line body, no literal `\n` in scripted commits (use multiple `-m` flags).
-- Include tests with behavior changes; verify message before push: `git log --format=medium -n 1`.
-- `pre-push`: `pnpm check:prepush`; CI: `pnpm check:quality`.
+Load only the matching playbook for the task:
 
-## Testing
+- Component authoring: `skills/component-authoring-react19/SKILL.md`
+- Verification scope and gates: `skills/verification-gates/SKILL.md`
+- Issue/branch/commit/PR flow: `skills/gh-issue-pr-flow/SKILL.md`
+- npm + tag + GitHub release flow: `skills/release-publisher/SKILL.md`
 
-- Vitest + Testing Library; prefer accessible role/name queries.
-- For component-only edits, run verification for the affected component(s) only; run full suite only for cross-cutting changes or done gate.
-- Test behavior + public API.
-- Prefer `play` assertions in existing `Default` story.
-- Test-only stories only when also documented.
+## Minimal Defaults
 
-## Release Runbook
-
-- Goal: keep npm package, git tag, and GitHub release aligned to the same version and commit.
-- Preferred path: after version bump commit, run `pnpm release:publish` to execute quality checks, dry-run, npm publish, tag push, and GitHub release creation in one flow.
-- Preflight:
-  - `git status --short` must be clean (or commit/stash unrelated work first).
-  - `npm whoami` should return the expected npm account.
-  - `gh auth status` should be valid for GitHub release/tag pushes.
-- Versioning:
-  - Bump `package.json` version before publishing (use semver).
-  - Commit the version bump before publish so the release can be tagged on that commit.
-- Verify before publish:
-  - `npm publish --dry-run`
-  - `pnpm check:quality` (or rely on `prepublishOnly`, but dry-run first)
-- Publish to npm:
-  - `npm publish`
-  - If npm 2FA is enabled and returns `EOTP`, rerun with `npm publish --otp <code>`.
-  - If npm returns `E403`, verify package ownership/name and token/account publish permissions.
-- Tagging (annotated tags only):
-  - Create `vX.Y.Z` on the exact commit that produced the published artifact: `git tag -a vX.Y.Z <commit> -m "vX.Y.Z"`
-  - Do not move/recreate a release tag after publish unless absolutely necessary.
-  - Verify target commit: `git show --no-patch --format=fuller vX.Y.Z`
-- Push sequence:
-  - `git push origin main`
-  - `git push origin vX.Y.Z`
-  - Verify remote tag target: `git ls-remote --tags origin "vX.Y.Z*"` (check `^{}` commit matches the published commit)
-- GitHub release:
-  - `gh release create vX.Y.Z --verify-tag --title "vX.Y.Z" --generate-notes`
-  - If the release already exists, update it with `gh release edit`.
-- Post-release verification:
-  - `npm view <package-name> version dist-tags --json`
-  - `gh release view vX.Y.Z`
-  - Optionally install-test from a clean app (`pnpm add <package-name>@X.Y.Z`)
-
-## Notes
-
-- Follow `eslint.config.mjs` and `.prettierrc.json`.
-- Update `README.md` for public API/usage changes.
-- Keep workflow/automation details in `AGENTS.md`, not `README.md`.
-- Do not commit or hand-edit `dist/`.
-- Before publish, confirm auth with `npm whoami` and verify the tarball with `npm publish --dry-run`.
+- Default delivery path is branch -> push -> PR (never push directly to `main`).
+- Include tests with behavior changes.
+- Update `README.md` when public API/usage changes.

--- a/skills/component-authoring-react19/SKILL.md
+++ b/skills/component-authoring-react19/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: component-authoring-react19
+description: Build or update React 19 TypeScript components for this library with production-ready styling, composable APIs, and matching stories/tests. Use when adding or refactoring components, props, styles, stories, or component exports.
+---
+
+# Component Authoring (React 19)
+
+Follow these rules for component work in this repository:
+
+- Build styled, production-ready components first.
+- Keep APIs composable and typed with explicit `Props` interfaces.
+- Split behavior and styling into separate modules when complexity grows.
+- Use function components with named exports.
+- Use React 19 `ref` prop pattern only; do not use `React.forwardRef`.
+- Prefer narrow unions and destructured defaults; do not use `defaultProps`.
+- Prefer shared tokens (for example `spacingTokens`) over raw sizes.
+- Do not use `calc(...)` sizing.
+- Prefer `Typography` for user-visible text.
+
+Use this file layout for components:
+
+- `src/components/<ComponentName>/<ComponentName>.tsx`
+- `src/components/<ComponentName>/<ComponentName>.css`
+- `src/components/<ComponentName>/<ComponentName>.stories.tsx`
+- `src/components/<ComponentName>/<ComponentName>.test.tsx`
+
+After adding a public component, export it from `src/index.ts`.
+
+For behavior changes, update tests and stories in the same component folder.

--- a/skills/gh-issue-pr-flow/SKILL.md
+++ b/skills/gh-issue-pr-flow/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: gh-issue-pr-flow
+description: Execute this repository's GitHub issue, branch, commit, and PR workflow with the gh CLI. Use when implementing issue-driven changes, preparing commits, pushing branches, or opening pull requests.
+---
+
+# GitHub Issue/PR Flow
+
+Use native `gh` CLI commands only.
+
+## Branch and Issue Flow
+
+1. Open issue context: `gh issue view <number>`
+2. Optionally start from issue branch: `gh issue develop <number> --checkout`
+3. Otherwise create a branch with prefix `codex/`.
+4. Implement and validate changes.
+5. Keep issue body focused on change summary + acceptance checks.
+6. Commit with issue linkage; use `Closes #<number>` or `Fixes #<number>` only when complete, otherwise use `Refs #<number>`.
+7. Push branch and create PR with `gh pr create`.
+8. Merge PR.
+9. Close issue manually only if auto-close did not trigger.
+
+## Commit and Label Conventions
+
+Use issue/commit format:
+
+- `<emoji> <type>(<scope>): <summary>`
+
+Allowed types:
+
+- `✨ feat`
+- `🐛 fix`
+- `🧹 chore`
+- `♻️ refactor`
+- `📝 docs`
+- `✅ test`
+- `🎨 style`
+- `⚡ perf`
+- `♿ a11y`
+- `👷 ci`
+- `🔧 build`
+
+Use labels in the shape `type: <emoji> <kind>`.
+Update labels with `gh label create ... --force`.
+
+## Commit Hygiene
+
+- Keep commits atomic.
+- Use imperative subject under 72 characters.
+- Keep body to 1-3 lines.
+- When scripting commits, pass multiple `-m` flags instead of literal `\n`.
+- Verify latest commit message with `git log --format=medium -n 1`.
+
+When asked to "commit and push", treat it as "commit, push, and open a PR" unless explicitly told not to open a PR.

--- a/skills/release-publisher/SKILL.md
+++ b/skills/release-publisher/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: release-publisher
+description: Publish this package to npm and keep npm version, git tag, and GitHub release aligned. Use when preparing or executing releases, including 2FA handling and release verification.
+---
+
+# Release Publisher
+
+Goal: keep npm package, git tag, and GitHub release aligned to the same commit/version.
+
+Preferred path:
+
+1. Confirm clean tree: `git status --short`
+2. Confirm auth: `npm whoami` and `gh auth status`
+3. Bump `package.json` version and commit it.
+4. Dry run: `npm publish --dry-run`
+5. Run quality gate: `pnpm check:quality`
+6. Run automated release flow: `pnpm release:publish`
+
+If npm 2FA prompts, rerun with:
+
+- `pnpm release:publish -- --otp <code>`
+
+## Manual Fallback
+
+If scripted release cannot be used, run manually:
+
+1. `npm publish` (or `npm publish --otp <code>`)
+2. Create annotated tag on the publish commit: `git tag -a vX.Y.Z <commit> -m "vX.Y.Z"`.
+3. Do not move or recreate a release tag after publish unless absolutely necessary.
+4. Push main and tag: `git push origin main` and `git push origin vX.Y.Z`.
+5. Create GitHub release: `gh release create vX.Y.Z --verify-tag --title "vX.Y.Z" --generate-notes`.
+6. If release already exists, use `gh release edit`.
+
+## Verification
+
+1. `npm view <package-name> version dist-tags --json`
+2. `gh release view vX.Y.Z`
+3. `git show --no-patch --format=fuller vX.Y.Z`
+4. `git ls-remote --tags origin "vX.Y.Z*"` and confirm the `^{}` commit matches the published commit.
+
+## Failure Handling
+
+- `EOTP`: rerun publish with `--otp <code>`.
+- `E403`: verify package ownership, package name, and npm token/account permissions.

--- a/skills/verification-gates/SKILL.md
+++ b/skills/verification-gates/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: verification-gates
+description: Select and run the right validation commands for this repo based on change scope. Use when deciding quick checks for component-only edits versus full quality gates before merge or release.
+---
+
+# Verification Gates
+
+Use `package.json` scripts as the source of truth.
+
+## Fast Path (component-only edits)
+
+Run the smallest checks that verify the edited component behavior:
+
+1. `pnpm lint`
+2. `pnpm test -- <component test path or filter>` when possible
+3. `pnpm test-storybook -- <story test path or filter>` when story `play` behavior changed
+
+If targeting is not reliable, run `pnpm test` instead.
+
+## Full Gate (cross-cutting or done gate)
+
+Run:
+
+1. `pnpm check:quality`
+
+This expands to lint + unit tests + build.
+
+## Useful Supporting Commands
+
+- `pnpm typecheck`
+- `pnpm format:check`
+- `pnpm lint:fix`
+- `pnpm test:watch`
+- `pnpm test-storybook:watch`
+
+Before pushing, run `pnpm check:prepush`.
+
+## Testing Conventions
+
+- Use Vitest + Testing Library.
+- Prefer accessible role/name queries.
+- Test behavior and public API.
+- Prefer `play` assertions in an existing `Default` story.
+- Add test-only stories only when they are also documented.


### PR DESCRIPTION
## Problem

Repository guidance can become noisy when always-on instructions, workflow details, and task-specific playbooks all live in one place. That increases prompt/context overhead and makes it easier for docs to drift away from the actual repo scripts.

## Why now

This repo has enough process around component work, verification, GitHub flow, and release steps that guidance quality has a direct effect on day-to-day velocity.

## Constraints

- Keep the important always-on rules easy to find.
- Align command guidance with the actual scripts and workflows that exist in the repo.
- Avoid spreading core policy across too many disconnected files.

## Desired outcome

- The default guidance is shorter and easier to keep current.
- Task-specific workflows can live in focused companion docs or playbooks where that is clearer.

## Non-goals

- Rewriting all contributor documentation.
- Changing the underlying scripts or GitHub workflow by documentation alone.

## Acceptance checks

- [ ] Core repo guidance is trimmed to the rules that should always be in view.
- [ ] Task-specific workflow details are moved to focused companion docs or playbooks if that improves clarity.
- [ ] Command guidance matches the current repo scripts.
- [ ] The resulting guidance is easier to follow and maintain.