### PR TITLE
🧹 chore(build): simplify package to ESM only

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,14 +20,12 @@
   "homepage": "https://github.com/youngxguo/yxgui#readme",
   "type": "module",
   "packageManager": "pnpm@9.15.2",
-  "main": "./dist/index.cjs.js",
-  "module": "./dist/index.es.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.es.js",
-      "require": "./dist/index.cjs.js"
+      "import": "./dist/index.js"
     }
   },
   "files": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,8 +14,8 @@ export default defineConfig({
   build: {
     lib: {
       entry: 'src/index.ts',
-      formats: ['es', 'cjs'],
-      fileName: (format) => `index.${format}.js`
+      formats: ['es'],
+      fileName: 'index'
     },
     rollupOptions: {
       external: ['react', 'react-dom']


### PR DESCRIPTION
## What changed

- Build a single ESM entry point at `dist/index.js`
- Remove the CommonJS package entry and the redundant `module` field
- Keep the package configuration focused on a modern Vite library skeleton

## Why

This repository is an intentionally minimal starting point and does not need compatibility machinery for older CommonJS consumers. Supporting only ESM removes an unnecessary output format and avoids maintaining two module-loading paths.

## Impact

Consumers should use modern `import` syntax. The package now ships one JavaScript entry point plus its TypeScript declaration file.

## Checks

- `pnpm check:quality`
- `pnpm format:check`
- `npm pack --dry-run --json`
- `git diff --check`