### PR TITLE
✨ feat(theme): add semantic theme provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 dist
 .DS_Store
+/.agents/
+/.claude/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-for fun ✨
+# yxgui
+
+An opinionated React component system with typed semantic themes.
+
+Create a theme with semantic values and apply it to any element subtree with
+`ThemeProvider`:
+
+```tsx
+import { createTheme, ThemeProvider } from 'yxgui';
+
+const theme = createTheme({
+  color: {
+    accent: '#006adc',
+    accentHover: '#0059c1',
+    onAccent: '#ffffff'
+  },
+  control: {
+    radius: '999px'
+  }
+});
+
+export function Example() {
+  return (
+    <ThemeProvider theme={theme}>
+      <main>Application content</main>
+    </ThemeProvider>
+  );
+}
+```
+
+Unspecified values inherit yxgui's defaults. `lightTheme` and `darkTheme` are also
+available as complete built-in themes. Theme values become stable `--yxg-*` CSS
+custom properties on the provider element, so nested providers and application CSS
+can customize the same semantic contract.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # yxgui
 
-An opinionated React component system with typed semantic themes.
+An opinionated React component system built with StyleX.
 
-Create a theme with semantic values and apply it to any element subtree with
-`ThemeProvider`:
+The foundation currently includes one Button, semantic themes, and a small public
+token set. Create a theme with typed semantic values and apply it to any element
+subtree with `ThemeProvider`:
 
 ```tsx
-import { createTheme, ThemeProvider } from 'yxgui';
+import { Button, createTheme, ThemeProvider } from 'yxgui';
+import 'yxgui/styles.css';
 
 const theme = createTheme({
   color: {
@@ -22,7 +24,7 @@ const theme = createTheme({
 export function Example() {
   return (
     <ThemeProvider theme={theme}>
-      <main>Application content</main>
+      <Button>Save changes</Button>
     </ThemeProvider>
   );
 }
@@ -31,4 +33,5 @@ export function Example() {
 Unspecified values inherit yxgui's defaults. `lightTheme` and `darkTheme` are also
 available as complete built-in themes. Theme values become stable `--yxg-*` CSS
 custom properties on the provider element, so nested providers and application CSS
-can customize the same semantic contract.
+can customize the same semantic contract. Applications own their global reset; the
+yxgui stylesheet contains only its compiled component and token CSS.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -4,40 +4,39 @@ yxgui will be a small, opinionated React component system with its own visual
 language, accessible behavior, and a coherent token foundation that applications
 can use and customize.
 
-StyleX is the styling backbone. Styles and themes are authored through StyleX
-and compiled to static CSS. Themeable public tokens use stable `--yxg-*` custom
-properties so they remain useful outside yxgui components.
+StyleX is the internal styling backbone. Component styles are compiled to JavaScript
+and static CSS before publication. Consumers create typed semantic theme objects,
+which yxgui maps to stable `--yxg-*` custom properties, so consumers never need to
+install StyleX or compile yxgui source.
 
 ## Guiding decisions
 
 - Tokens are a public contract, but they are developed alongside real interface
   needs rather than designed exhaustively up front.
-- StyleX is the single styling and composition system for yxgui and the
-  recommended system for applications built with it.
+- StyleX is the single styling and composition system inside yxgui. Applications
+  may use any styling system that can consume CSS custom properties.
 - Themeable values, fixed style constants, and JavaScript values remain distinct
   contracts. Each is exposed only when consumers need it.
-- Themes apply to ordinary element subtrees. React context is not required for
-  components to receive theme values.
+- Themes apply through a provider element to ordinary element subtrees. React
+  context is not required for components to receive theme values.
 - Component CSS is extracted at build time. Runtime style injection is not part
   of the architecture.
 - Plain CSS is limited to a small, documented global entry point and platform
   cases that are not a good fit for StyleX.
 - Components prefer native HTML behavior. More complex behavior must remain
   accessible, reliable, and independent of yxgui's visual design.
-- yxgui starts as a package. Source distribution or a CLI can be reconsidered
-  after real usage demonstrates a need.
+- yxgui ships as a compiled package rather than distributing StyleX source for
+  consuming applications to build.
 
 ## Phases
 
 ### 1. Prove the foundation
 
-- Configure the official StyleX toolchain for the library, tests, and a small
-  playground.
+- Configure the official StyleX toolchain for the library and tests.
 - Build a minimal spike with representative tokens, two themes, and one styled
   component.
-- Pack the library and install it in a clean Vite application.
-- Verify static CSS output, required imports, public token use, theme application,
-  and scoped overrides.
+- Verify static CSS output, required imports, semantic theme creation, public CSS
+  variable customization, provider application, and scoped overrides.
 - Settle the minimum package and consumer contract before expanding the system.
 
 ### 2. Establish the design through a vertical slice
@@ -58,7 +57,7 @@ properties so they remain useful outside yxgui components.
 - Define StyleX conventions for parts, variants, interaction states, responsive
   styles, and intentional consumer overrides.
 - Establish the supported browser and React environment.
-- Add behavior, accessibility, and visual testing to the playground.
+- Add behavior, accessibility, and visual testing for components.
 - Define the completion checklist shared by every component.
 
 ### 4. Complete the essential controls
@@ -79,7 +78,6 @@ properties so they remain useful outside yxgui components.
 
 - Add advanced components only when an application needs them.
 - Stabilize package exports, documentation, compatibility, and release policy.
-- Revisit source distribution after yxgui has been used in real applications.
 
 ## Not yet
 

--- a/docs/token-rfc.md
+++ b/docs/token-rfc.md
@@ -9,8 +9,9 @@
 Tokens give yxgui a coherent default visual language and let consuming
 applications use the same design decisions outside yxgui components.
 
-StyleX is the canonical styling and theme layer. Themeable public tokens are
-typed StyleX variables backed by stable `--yxg-*` CSS custom properties. The
+StyleX is the internal styling layer. Themeable values are authored against StyleX
+variables and compiled into stable `--yxg-*` CSS custom properties. Consumers
+configure those properties through a typed semantic theme object and provider. The
 initial system will be intentionally small and will grow from real component and
 application needs.
 
@@ -31,6 +32,7 @@ application needs.
 - Tokenizing every CSS declaration
 - Designing component APIs
 - Supporting multiple styling systems
+- Publishing StyleX source for consuming applications to compile
 - Defining long-term compatibility policy before the first package contract is
   proven
 
@@ -64,20 +66,22 @@ designed and evaluated together.
 
 ### Themeable variables
 
-Values that change with a theme use StyleX variables and public `--yxg-*` CSS
-custom properties. These are the normal integration point for components,
-application styles, plain CSS, and third-party UI.
+Values that change with a theme are authored as StyleX variables and emitted as
+public `--yxg-*` CSS custom properties. The custom properties are the normal
+integration point for components, application styles, and third-party UI.
 
 ### Static constants
 
 Fixed style decisions that do not need runtime theming remain compile-time
 constants. Examples may include breakpoints or shared layer ordering.
 
-### JavaScript values
+### JavaScript theme contract
 
-StyleX variables are CSS identifiers rather than JavaScript data. A separate
-JavaScript contract will be added only for genuine non-CSS consumers such as
-charts. The package does not need to duplicate every token in JavaScript.
+Internal StyleX variables are not exported as a consumer API. Consumers provide
+semantic theme options through `createTheme`, and `ThemeProvider` maps the complete
+theme to the public CSS custom properties on an element subtree. Separate raw
+JavaScript token values will be added only for genuine non-CSS consumers such as
+charts.
 
 ## Conceptual model
 
@@ -103,8 +107,9 @@ layout will follow from the prototype.
 
 ## Themes
 
-Themes must work by applying StyleX props to an ordinary element and must affect
-that element's subtree without React context.
+Themes must work by passing a semantic theme object to a provider element and must
+affect that element's subtree through CSS inheritance rather than component-level
+React context.
 
 The first implementation should demonstrate:
 
@@ -124,15 +129,16 @@ must prove the supported combinations rather than assume arbitrary themes merge.
 Consumers must be able to:
 
 - Use the default yxgui design without theme configuration.
-- Use shared tokens in StyleX application styles.
-- Use stable `--yxg-*` custom properties in plain CSS and third-party code.
+- Create a typed semantic theme without installing or configuring StyleX.
+- Use stable `--yxg-*` custom properties in application styles and third-party
+  code.
 - Apply global and scoped themes without component-specific mode logic.
 - Inspect active values in browser developer tools.
 - Access JavaScript values where a demonstrated non-CSS use case requires them.
 
-Before the token contract is accepted, a packed release must work in a clean
-consumer application. That proof should establish CSS loading, package exports,
-StyleX toolchain expectations, reset ownership, and scoped theme behavior.
+Before the token contract is accepted, the compiled package build must establish
+CSS loading, package exports, reset ownership, and scoped theme behavior without
+requiring consumers to process yxgui source.
 
 ## Accessibility
 
@@ -164,7 +170,7 @@ The token system succeeds when:
 
 ## Next steps
 
-1. Prove the StyleX package contract with a minimal packed-library fixture.
+1. Prove the compiled package contract in the library build and tests.
 2. Define the visual direction and initial inventory alongside a small settings
    interface.
 3. Test the required theme combinations and consumer overrides.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,5 @@
 import js from '@eslint/js';
+import * as stylexPlugin from '@stylexjs/eslint-plugin';
 import eslintConfigPrettier from 'eslint-config-prettier';
 import globals from 'globals';
 import prettierPlugin from 'eslint-plugin-prettier';
@@ -31,7 +32,8 @@ export default tseslint.config(
     plugins: {
       prettier: prettierPlugin,
       react: reactPlugin,
-      'react-hooks': reactHooksPlugin
+      'react-hooks': reactHooksPlugin,
+      '@stylexjs': stylexPlugin
     },
     settings: {
       react: {
@@ -50,6 +52,9 @@ export default tseslint.config(
         }
       ],
       'prettier/prettier': 'error',
+      '@stylexjs/no-conflicting-props': 'error',
+      '@stylexjs/valid-shorthands': 'error',
+      '@stylexjs/valid-styles': 'error',
       '@typescript-eslint/no-unused-vars': [
         'error',
         {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yxgui",
   "version": "0.1.0",
-  "description": "Minimal Vite React TypeScript library",
+  "description": "Opinionated React component system with typed semantic themes",
   "keywords": [
     "react",
     "ui",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yxgui",
   "version": "0.1.0",
-  "description": "Opinionated React component system with typed semantic themes",
+  "description": "Opinionated React component system built with StyleX",
   "keywords": [
     "react",
     "ui",
@@ -26,8 +26,12 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
-    }
+    },
+    "./styles.css": "./dist/style.css"
   },
+  "sideEffects": [
+    "**/*.css"
+  ],
   "files": [
     "dist",
     "README.md",
@@ -53,6 +57,9 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.3",
+    "@stylexjs/eslint-plugin": "^0.19.0",
+    "@stylexjs/stylex": "^0.19.0",
+    "@stylexjs/unplugin": "^0.19.0",
     "@types/node": "^25.3.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
@@ -68,6 +75,7 @@
     "react-dom": "^19.2.4",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.56.0",
+    "unplugin": "^2.3.11",
     "vite": "^7.3.1",
     "vite-plugin-dts": "^4.5.4",
     "vitest": "^4.0.18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,15 @@ importers:
       '@eslint/js':
         specifier: ^9.39.3
         version: 9.39.3
+      '@stylexjs/eslint-plugin':
+        specifier: ^0.19.0
+        version: 0.19.0
+      '@stylexjs/stylex':
+        specifier: ^0.19.0
+        version: 0.19.0
+      '@stylexjs/unplugin':
+        specifier: ^0.19.0
+        version: 0.19.0(unplugin@2.3.11)
       '@types/node':
         specifier: ^25.3.0
         version: 25.3.0
@@ -60,6 +69,9 @@ importers:
       typescript-eslint:
         specifier: ^8.56.0
         version: 8.56.0(eslint@9.39.3)(typescript@5.9.3)
+      unplugin:
+        specifier: ^2.3.11
+        version: 2.3.11
       vite:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@25.3.0)(lightningcss@1.31.1)
@@ -122,6 +134,10 @@ packages:
     resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
@@ -142,6 +158,24 @@ packages:
     resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/plugin-syntax-flow@7.29.7':
+    resolution: {integrity: sha512-ajMX6QPcyomotqwpzhkYGxcK2i/us0rs1Qo9QvUpa+Fca0FTmqrzKrctoIYLMxcOhGZldGT/BAVkRGTWBiR8gQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-jsx@7.29.7':
+    resolution: {integrity: sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-typescript@7.29.7':
+    resolution: {integrity: sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
 
   '@babel/plugin-transform-react-jsx-self@7.27.1':
     resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
@@ -198,9 +232,16 @@ packages:
   '@csstools/css-syntax-patches-for-csstree@1.0.28':
     resolution: {integrity: sha512-1NRf1CUBjnr3K7hu8BLxjQrKCxEe8FP/xmPTenAxCRZWVLbmGotkFvG9mfNpjA6k7Bw1bw4BilZq9cu19RA5pg==}
 
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
+
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@dual-bundle/import-meta-resolve@4.2.1':
+    resolution: {integrity: sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==}
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -627,6 +668,23 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@stylexjs/babel-plugin@0.19.0':
+    resolution: {integrity: sha512-2SnVZIl047TtqKW0nRTn7Irz0kmoot1bxdGDE/HwfwfF7dJYHqwkIFg92s87v3hj7zxJobrHWwDx1p3qvQXW4g==}
+
+  '@stylexjs/eslint-plugin@0.19.0':
+    resolution: {integrity: sha512-zZ6bCYcciaj2YYO0cG2nyCfjX5rclmW+WkcW/84gx4wCtpLvfr9+zYd3oqESr48suFlr8p6hrxGwnjYSLTDD4g==}
+
+  '@stylexjs/shared@0.19.0':
+    resolution: {integrity: sha512-7Yym70cQH5sPzJHgzJX3FkL9ZCptbC3IbiRijN9YLYU/5OywB/3c519Xv1DOzvxqjv8urSxh98/9HxLaPG7sDg==}
+
+  '@stylexjs/stylex@0.19.0':
+    resolution: {integrity: sha512-CnUFp7YMaDLDeemsWOfJgoC/gKM5P/yBNMcpJaE6ChJmXr7s0DJwSeGTTlHJcqqwN9OW1qGtmARWLFhGZN1pTA==}
+
+  '@stylexjs/unplugin@0.19.0':
+    resolution: {integrity: sha512-2QwNYovSwarC/M8DLD78857F6MEi4eQ3UYzgdmyg/K7562M/rV1KWptiATxcKgujlUT6ToNy778SOXf4bGK+Bw==}
+    peerDependencies:
+      unplugin: ^2.3.11
+
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
 
@@ -913,6 +971,10 @@ packages:
     resolution: {integrity: sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==}
     engines: {node: 20 || >=22}
 
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -970,6 +1032,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-mediaquery@0.1.2:
+    resolution: {integrity: sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==}
 
   css-tree@3.1.0:
     resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
@@ -1215,6 +1280,10 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -1370,6 +1439,9 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
+  invariant@2.2.4:
+    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
@@ -1429,6 +1501,10 @@ packages:
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
     engines: {node: '>= 0.4'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -1646,6 +1722,10 @@ packages:
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
   minimatch@10.2.1:
     resolution: {integrity: sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==}
     engines: {node: 20 || >=22}
@@ -1759,6 +1839,10 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
@@ -1790,6 +1874,9 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -1989,6 +2076,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  styleq@0.2.1:
+    resolution: {integrity: sha512-L0TR0NQb+X4/ktDEKmjWyp27gla+LUYi/by5k5SjKXf6/pvZP7wbwEB5J+tqxdFVPgzbsuz+d4RTScO/QZquBw==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -2029,6 +2119,10 @@ packages:
   tldts@7.0.23:
     resolution: {integrity: sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==}
     hasBin: true
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -2102,6 +2196,10 @@ packages:
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
+
+  unplugin@2.3.11:
+    resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
+    engines: {node: '>=18.12.0'}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -2205,6 +2303,9 @@ packages:
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
+
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
@@ -2372,6 +2473,8 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
+  '@babel/helper-plugin-utils@7.29.7': {}
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
@@ -2386,6 +2489,21 @@ snapshots:
   '@babel/parser@7.29.0':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/plugin-syntax-flow@7.29.7(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
     dependencies:
@@ -2450,8 +2568,12 @@ snapshots:
   '@csstools/css-syntax-patches-for-csstree@1.0.28':
     optional: true
 
+  '@csstools/css-tokenizer@3.0.4': {}
+
   '@csstools/css-tokenizer@4.0.0':
     optional: true
+
+  '@dual-bundle/import-meta-resolve@4.2.1': {}
 
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
@@ -2776,6 +2898,47 @@ snapshots:
       - '@types/node'
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@stylexjs/babel-plugin@0.19.0':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@dual-bundle/import-meta-resolve': 4.2.1
+      '@stylexjs/shared': 0.19.0
+      '@stylexjs/stylex': 0.19.0
+      postcss-value-parser: 4.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@stylexjs/eslint-plugin@0.19.0':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+      '@stylexjs/shared': 0.19.0
+      micromatch: 4.0.8
+      postcss-value-parser: 4.2.0
+
+  '@stylexjs/shared@0.19.0': {}
+
+  '@stylexjs/stylex@0.19.0':
+    dependencies:
+      css-mediaquery: 0.1.2
+      invariant: 2.2.4
+      styleq: 0.2.1
+
+  '@stylexjs/unplugin@0.19.0(unplugin@2.3.11)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-syntax-flow': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.0)
+      '@stylexjs/babel-plugin': 0.19.0
+      browserslist: 4.28.1
+      lightningcss: 1.31.1
+      unplugin: 2.3.11
+    transitivePeerDependencies:
+      - supports-color
 
   '@types/argparse@1.0.38': {}
 
@@ -3177,6 +3340,10 @@ snapshots:
     dependencies:
       balanced-match: 4.0.3
 
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
   browserslist@4.28.1:
     dependencies:
       baseline-browser-mapping: 2.10.0
@@ -3234,6 +3401,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-mediaquery@0.1.2: {}
 
   css-tree@3.1.0:
     dependencies:
@@ -3300,8 +3469,7 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   diff@8.0.3: {}
 
@@ -3598,6 +3766,10 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -3756,6 +3928,10 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.1.0
 
+  invariant@2.2.4:
+    dependencies:
+      loose-envify: 1.4.0
+
   is-array-buffer@3.0.5:
     dependencies:
       call-bind: 1.0.8
@@ -3822,6 +3998,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
+
+  is-number@7.0.0: {}
 
   is-potential-custom-element-name@1.0.1:
     optional: true
@@ -3998,7 +4176,6 @@ snapshots:
       lightningcss-linux-x64-musl: 1.31.1
       lightningcss-win32-arm64-msvc: 1.31.1
       lightningcss-win32-x64-msvc: 1.31.1
-    optional: true
 
   local-pkg@1.1.2:
     dependencies:
@@ -4037,6 +4214,11 @@ snapshots:
 
   mdn-data@2.12.2:
     optional: true
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
 
   minimatch@10.2.1:
     dependencies:
@@ -4159,6 +4341,8 @@ snapshots:
 
   picocolors@1.1.1: {}
 
+  picomatch@2.3.2: {}
+
   picomatch@4.0.3: {}
 
   pixelmatch@7.1.0:
@@ -4192,6 +4376,8 @@ snapshots:
     optional: true
 
   possible-typed-array-names@1.1.0: {}
+
+  postcss-value-parser@4.2.0: {}
 
   postcss@8.5.6:
     dependencies:
@@ -4460,6 +4646,8 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  styleq@0.2.1: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -4495,6 +4683,10 @@ snapshots:
     dependencies:
       tldts-core: 7.0.23
     optional: true
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
 
   totalist@3.0.1:
     optional: true
@@ -4580,6 +4772,13 @@ snapshots:
     optional: true
 
   universalify@2.0.1: {}
+
+  unplugin@2.3.11:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      acorn: 8.16.0
+      picomatch: 4.0.3
+      webpack-virtual-modules: 0.6.2
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
@@ -4671,6 +4870,8 @@ snapshots:
 
   webidl-conversions@8.0.1:
     optional: true
+
+  webpack-virtual-modules@0.6.2: {}
 
   whatwg-mimetype@5.0.0:
     optional: true

--- a/src/Button.test.tsx
+++ b/src/Button.test.tsx
@@ -1,0 +1,21 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { Button } from './Button';
+
+describe('Button', () => {
+  it('renders native button behavior with compiled styles', () => {
+    const markup = renderToStaticMarkup(<Button disabled>Save</Button>);
+
+    expect(markup).toContain('<button');
+    expect(markup).toContain('type="button"');
+    expect(markup).toContain('disabled=""');
+    expect(markup).toContain('class="');
+    expect(markup).toContain('>Save</button>');
+  });
+
+  it('allows the native button type to be selected', () => {
+    const markup = renderToStaticMarkup(<Button type="submit">Save</Button>);
+
+    expect(markup).toContain('type="submit"');
+  });
+});

--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -1,0 +1,51 @@
+import * as stylex from '@stylexjs/stylex';
+import type { ComponentPropsWithoutRef } from 'react';
+import { tokens } from './tokens.stylex';
+
+export type ButtonProps = Omit<ComponentPropsWithoutRef<'button'>, 'className' | 'style'>;
+
+const styles = stylex.create({
+  root: {
+    alignItems: 'center',
+    backgroundColor: {
+      default: tokens['--yxg-color-accent'],
+      ':hover': tokens['--yxg-color-accent-hover'],
+      ':disabled': tokens['--yxg-color-border']
+    },
+    borderColor: 'transparent',
+    borderRadius: tokens['--yxg-radius-control'],
+    borderStyle: 'solid',
+    borderWidth: 1,
+    boxSizing: 'border-box',
+    color: {
+      default: tokens['--yxg-color-on-accent'],
+      ':disabled': tokens['--yxg-color-text-muted']
+    },
+    cursor: {
+      default: 'pointer',
+      ':disabled': 'not-allowed'
+    },
+    display: 'inline-flex',
+    fontFamily: tokens['--yxg-font-body'],
+    fontSize: '0.9375rem',
+    fontWeight: 650,
+    height: tokens['--yxg-control-height'],
+    justifyContent: 'center',
+    outlineColor: {
+      default: 'transparent',
+      ':focus-visible': tokens['--yxg-color-focus']
+    },
+    outlineOffset: 3,
+    outlineStyle: 'solid',
+    outlineWidth: 2,
+    paddingInline: tokens['--yxg-control-padding-inline'],
+    transitionDuration: tokens['--yxg-duration-fast'],
+    transitionProperty: 'background-color, color',
+    transitionTimingFunction: tokens['--yxg-ease-standard'],
+    userSelect: 'none'
+  }
+});
+
+export function Button({ type = 'button', ...props }: ButtonProps) {
+  return <button type={type} {...props} {...stylex.props(styles.root)} />;
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,8 +1,0 @@
-import { describe, expect, it } from 'vitest';
-import { packageName } from './index';
-
-describe('packageName', () => {
-  it('exposes the package name', () => {
-    expect(packageName).toBe('yxgui');
-  });
-});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,9 @@
-export const packageName = 'yxgui';
+export {
+  createTheme,
+  darkTheme,
+  lightTheme,
+  ThemeProvider,
+  type Theme,
+  type ThemeOptions,
+  type ThemeProviderProps
+} from './theme';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+import './style.css';
+
+export { Button, type ButtonProps } from './Button';
 export {
   createTheme,
   darkTheme,

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,1 @@
+@layer yxgui.reset;

--- a/src/theme.test.tsx
+++ b/src/theme.test.tsx
@@ -1,0 +1,51 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { createTheme, darkTheme, lightTheme, ThemeProvider } from './theme';
+
+describe('createTheme', () => {
+  it('merges semantic overrides with the default theme', () => {
+    const theme = createTheme({
+      color: { accent: '#006adc' },
+      control: { radius: '999px' }
+    });
+
+    expect(theme.color.accent).toBe('#006adc');
+    expect(theme.color.canvas).toBe(lightTheme.color.canvas);
+    expect(theme.control.radius).toBe('999px');
+    expect(theme.control.height).toBe(lightTheme.control.height);
+  });
+
+  it('provides a complete dark theme', () => {
+    expect(darkTheme.color.canvas).toBe('#171716');
+    expect(darkTheme.typography).toEqual(lightTheme.typography);
+    expect(darkTheme.motion).toEqual(lightTheme.motion);
+  });
+});
+
+describe('ThemeProvider', () => {
+  it('scopes semantic theme values to its element subtree', () => {
+    const theme = createTheme({ color: { accent: '#006adc' } });
+    const markup = renderToStaticMarkup(
+      <ThemeProvider theme={theme} id="custom-theme">
+        Application content
+      </ThemeProvider>
+    );
+
+    expect(markup).toContain('<div id="custom-theme" data-yxgui-theme=""');
+    expect(markup).toContain('--yxg-color-accent:#006adc');
+    expect(markup).toContain('--yxg-control-height:2.75rem');
+    expect(markup).toContain('>Application content</div>');
+  });
+
+  it('preserves ordinary element props and consumer styles', () => {
+    const markup = renderToStaticMarkup(
+      <ThemeProvider className="app-shell" style={{ minHeight: '100vh' }} theme={darkTheme}>
+        Content
+      </ThemeProvider>
+    );
+
+    expect(markup).toContain('class="app-shell"');
+    expect(markup).toContain('min-height:100vh');
+    expect(markup).toContain('--yxg-color-canvas:#171716');
+  });
+});

--- a/src/theme.test.tsx
+++ b/src/theme.test.tsx
@@ -1,5 +1,6 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
+import { Button } from './Button';
 import { createTheme, darkTheme, lightTheme, ThemeProvider } from './theme';
 
 describe('createTheme', () => {
@@ -27,14 +28,14 @@ describe('ThemeProvider', () => {
     const theme = createTheme({ color: { accent: '#006adc' } });
     const markup = renderToStaticMarkup(
       <ThemeProvider theme={theme} id="custom-theme">
-        Application content
+        <Button>Save</Button>
       </ThemeProvider>
     );
 
     expect(markup).toContain('<div id="custom-theme" data-yxgui-theme=""');
     expect(markup).toContain('--yxg-color-accent:#006adc');
     expect(markup).toContain('--yxg-control-height:2.75rem');
-    expect(markup).toContain('>Application content</div>');
+    expect(markup).toContain('<button');
   });
 
   it('preserves ordinary element props and consumer styles', () => {

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -1,0 +1,119 @@
+import type { ComponentPropsWithoutRef, CSSProperties } from 'react';
+
+export interface Theme {
+  color: {
+    canvas: string;
+    surface: string;
+    text: string;
+    textMuted: string;
+    border: string;
+    accent: string;
+    accentHover: string;
+    onAccent: string;
+    focus: string;
+  };
+  typography: {
+    bodyFontFamily: string;
+  };
+  control: {
+    height: string;
+    paddingInline: string;
+    radius: string;
+  };
+  motion: {
+    durationFast: string;
+    easingStandard: string;
+  };
+}
+
+export type ThemeOptions = {
+  [Section in keyof Theme]?: Partial<Theme[Section]>;
+};
+
+const defaultTheme: Theme = {
+  color: {
+    canvas: '#f7f7f4',
+    surface: '#ffffff',
+    text: '#20201e',
+    textMuted: '#66655f',
+    border: '#d9d8d1',
+    accent: '#5b47d6',
+    accentHover: '#4936bd',
+    onAccent: '#ffffff',
+    focus: '#7969e8'
+  },
+  typography: {
+    bodyFontFamily:
+      'Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif'
+  },
+  control: {
+    height: '2.75rem',
+    paddingInline: '1rem',
+    radius: '0.75rem'
+  },
+  motion: {
+    durationFast: '140ms',
+    easingStandard: 'cubic-bezier(0.2, 0, 0, 1)'
+  }
+};
+
+export function createTheme(options: ThemeOptions = {}): Theme {
+  return {
+    color: { ...defaultTheme.color, ...options.color },
+    typography: { ...defaultTheme.typography, ...options.typography },
+    control: { ...defaultTheme.control, ...options.control },
+    motion: { ...defaultTheme.motion, ...options.motion }
+  };
+}
+
+export const lightTheme: Theme = createTheme();
+
+export const darkTheme: Theme = createTheme({
+  color: {
+    canvas: '#171716',
+    surface: '#232321',
+    text: '#f5f4ef',
+    textMuted: '#aaa9a2',
+    border: '#42413c',
+    accent: '#9b8cf3',
+    accentHover: '#ad9fff',
+    onAccent: '#171326',
+    focus: '#b7acff'
+  }
+});
+
+type ThemeCSSProperties = CSSProperties & {
+  [Variable in `--yxg-${string}`]?: string;
+};
+
+function themeToCSSProperties(theme: Theme): ThemeCSSProperties {
+  return {
+    '--yxg-color-canvas': theme.color.canvas,
+    '--yxg-color-surface': theme.color.surface,
+    '--yxg-color-text': theme.color.text,
+    '--yxg-color-text-muted': theme.color.textMuted,
+    '--yxg-color-border': theme.color.border,
+    '--yxg-color-accent': theme.color.accent,
+    '--yxg-color-accent-hover': theme.color.accentHover,
+    '--yxg-color-on-accent': theme.color.onAccent,
+    '--yxg-color-focus': theme.color.focus,
+    '--yxg-font-body': theme.typography.bodyFontFamily,
+    '--yxg-control-height': theme.control.height,
+    '--yxg-control-padding-inline': theme.control.paddingInline,
+    '--yxg-radius-control': theme.control.radius,
+    '--yxg-duration-fast': theme.motion.durationFast,
+    '--yxg-ease-standard': theme.motion.easingStandard
+  };
+}
+
+export type ThemeProviderProps = ComponentPropsWithoutRef<'div'> & {
+  theme: Theme;
+};
+
+export function ThemeProvider({ theme, style, children, ...props }: ThemeProviderProps) {
+  return (
+    <div {...props} data-yxgui-theme="" style={{ ...themeToCSSProperties(theme), ...style }}>
+      {children}
+    </div>
+  );
+}

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -1,4 +1,5 @@
 import type { ComponentPropsWithoutRef, CSSProperties } from 'react';
+import { defaultTheme } from './tokens.stylex';
 
 export interface Theme {
   color: {
@@ -28,33 +29,6 @@ export interface Theme {
 
 export type ThemeOptions = {
   [Section in keyof Theme]?: Partial<Theme[Section]>;
-};
-
-const defaultTheme: Theme = {
-  color: {
-    canvas: '#f7f7f4',
-    surface: '#ffffff',
-    text: '#20201e',
-    textMuted: '#66655f',
-    border: '#d9d8d1',
-    accent: '#5b47d6',
-    accentHover: '#4936bd',
-    onAccent: '#ffffff',
-    focus: '#7969e8'
-  },
-  typography: {
-    bodyFontFamily:
-      'Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif'
-  },
-  control: {
-    height: '2.75rem',
-    paddingInline: '1rem',
-    radius: '0.75rem'
-  },
-  motion: {
-    durationFast: '140ms',
-    easingStandard: 'cubic-bezier(0.2, 0, 0, 1)'
-  }
 };
 
 export function createTheme(options: ThemeOptions = {}): Theme {

--- a/src/tokens.stylex.ts
+++ b/src/tokens.stylex.ts
@@ -1,0 +1,47 @@
+import * as stylex from '@stylexjs/stylex';
+import type { Theme } from './theme';
+
+export const defaultTheme: Theme = {
+  color: {
+    canvas: '#f7f7f4',
+    surface: '#ffffff',
+    text: '#20201e',
+    textMuted: '#66655f',
+    border: '#d9d8d1',
+    accent: '#5b47d6',
+    accentHover: '#4936bd',
+    onAccent: '#ffffff',
+    focus: '#7969e8'
+  },
+  typography: {
+    bodyFontFamily:
+      'Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif'
+  },
+  control: {
+    height: '2.75rem',
+    paddingInline: '1rem',
+    radius: '0.75rem'
+  },
+  motion: {
+    durationFast: '140ms',
+    easingStandard: 'cubic-bezier(0.2, 0, 0, 1)'
+  }
+};
+
+export const tokens = stylex.defineVars({
+  '--yxg-color-canvas': defaultTheme.color.canvas,
+  '--yxg-color-surface': defaultTheme.color.surface,
+  '--yxg-color-text': defaultTheme.color.text,
+  '--yxg-color-text-muted': defaultTheme.color.textMuted,
+  '--yxg-color-border': defaultTheme.color.border,
+  '--yxg-color-accent': defaultTheme.color.accent,
+  '--yxg-color-accent-hover': defaultTheme.color.accentHover,
+  '--yxg-color-on-accent': defaultTheme.color.onAccent,
+  '--yxg-color-focus': defaultTheme.color.focus,
+  '--yxg-font-body': defaultTheme.typography.bodyFontFamily,
+  '--yxg-control-height': defaultTheme.control.height,
+  '--yxg-control-padding-inline': defaultTheme.control.paddingInline,
+  '--yxg-radius-control': defaultTheme.control.radius,
+  '--yxg-duration-fast': defaultTheme.motion.durationFast,
+  '--yxg-ease-standard': defaultTheme.motion.easingStandard
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
       fileName: 'index'
     },
     rollupOptions: {
-      external: ['react', 'react-dom']
+      external: [/^react(?:\/.*)?$/, /^react-dom(?:\/.*)?$/]
     }
   }
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,18 +1,31 @@
+import stylex from '@stylexjs/unplugin';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 
 export default defineConfig({
   plugins: [
+    stylex.vite({
+      unstable_moduleResolution: {
+        type: 'commonJS',
+        rootDir: fileURLToPath(new URL('.', import.meta.url))
+      },
+      useCSSLayers: {
+        before: ['yxgui.reset'],
+        prefix: 'yxgui'
+      }
+    }),
     react(),
     dts({
       include: ['src'],
-      exclude: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+      exclude: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'src/tokens.stylex.ts'],
       insertTypesEntry: true
     })
   ],
   build: {
     lib: {
+      cssFileName: 'style',
       entry: 'src/index.ts',
       formats: ['es'],
       fileName: 'index'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,18 @@
+import stylex from '@stylexjs/unplugin';
+import react from '@vitejs/plugin-react';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  plugins: [
+    stylex.rollup({
+      unstable_moduleResolution: {
+        type: 'commonJS',
+        rootDir: fileURLToPath(new URL('.', import.meta.url))
+      }
+    }),
+    react()
+  ],
   test: {
     environment: 'node'
   }


### PR DESCRIPTION
## summary

- add typed semantic themes with createTheme, built-in light and dark themes, and a DOM-scoped ThemeProvider
- map semantic values to the public --yxg-* CSS properties with only React as a runtime peer
- update the package contract, README example, architecture docs, and theme tests

## why

This establishes the consumer-facing runtime theme contract independently from the internal styling engine. StyleX and components can build on this contract in #94.

## checks

- pnpm check:quality
- pnpm format:check
- packed tarball installed and rendered in a clean pnpm consumer with no StyleX dependency