### PR TITLE
✨ feat(button): prevent consumer style overrides

### DIFF
--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -1,7 +1,7 @@
 import * as stylex from '@stylexjs/stylex';
 import type { ComponentProps } from 'react';
 
-export type ButtonProps = ComponentProps<'button'>;
+export type ButtonProps = Omit<ComponentProps<'button'>, 'className' | 'style'>;
 
 const styles = stylex.create({
   root: {
@@ -9,14 +9,6 @@ const styles = stylex.create({
   }
 });
 
-export function Button({ className, style, ...props }: ButtonProps) {
-  const stylexProps = stylex.props(styles.root);
-
-  return (
-    <button
-      {...props}
-      className={[stylexProps.className, className].filter(Boolean).join(' ')}
-      style={{ ...stylexProps.style, ...style }}
-    />
-  );
+export function Button(props: ButtonProps) {
+  return <button {...props} {...stylex.props(styles.root)} />;
 }


### PR DESCRIPTION
## summary

- remove `className` and `style` from the Button public API so the component owns its styling through StyleX
- apply generated StyleX props directly to the native button

## checks

- `pnpm check:quality`