### PR TITLE
🔧 chore(lint): simplify eslint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,61 +1,32 @@
+// @ts-check
+
 import js from '@eslint/js';
+import { defineConfig } from 'eslint/config';
 import eslintConfigPrettier from 'eslint-config-prettier';
-import globals from 'globals';
 import reactPlugin from 'eslint-plugin-react';
 import reactHooksPlugin from 'eslint-plugin-react-hooks';
 import tseslint from 'typescript-eslint';
 
-export default tseslint.config(
+export default defineConfig(
   {
     ignores: ['dist/**', 'storybook-static/**']
   },
-  js.configs.recommended,
-  ...tseslint.configs.recommended,
-  eslintConfigPrettier,
   {
-    files: ['**/*.{js,mjs,cjs,jsx,ts,tsx}'],
-    languageOptions: {
-      ecmaVersion: 'latest',
-      sourceType: 'module',
-      parserOptions: {
-        ecmaFeatures: {
-          jsx: true
-        }
-      },
-      globals: {
-        ...globals.browser,
-        ...globals.node
-      }
-    },
-    plugins: {
-      react: reactPlugin,
-      'react-hooks': reactHooksPlugin
-    },
+    files: ['**/*.{js,ts,tsx}'],
+    extends: [js.configs.recommended, tseslint.configs.recommended]
+  },
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    extends: [
+      reactPlugin.configs.flat.recommended,
+      reactPlugin.configs.flat['jsx-runtime'],
+      reactHooksPlugin.configs.flat.recommended
+    ],
     settings: {
       react: {
         version: 'detect'
       }
-    },
-    rules: {
-      ...reactPlugin.configs.recommended.rules,
-      ...reactHooksPlugin.configs.recommended.rules,
-      '@typescript-eslint/no-unused-vars': [
-        'error',
-        {
-          argsIgnorePattern: '^_',
-          varsIgnorePattern: '^_',
-          caughtErrorsIgnorePattern: '^_'
-        }
-      ],
-      'react/react-in-jsx-scope': 'off'
     }
   },
-  {
-    files: ['**/*.{test,spec}.{js,mjs,cjs,jsx,ts,tsx}'],
-    languageOptions: {
-      globals: {
-        ...globals.vitest
-      }
-    }
-  }
+  eslintConfigPrettier
 );

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
   },
   "scripts": {
     "check:quality": "pnpm lint && pnpm format:check && pnpm test && pnpm build && pnpm build-storybook",
-    "lint": "eslint . --ext .js,.jsx,.ts,.tsx,.mjs,.cjs",
-    "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx,.mjs,.cjs --fix",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run --passWithNoTests",
@@ -71,7 +71,6 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
-    "globals": "^17.3.0",
     "prettier": "^3.8.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,9 +48,6 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^7.0.1
         version: 7.1.1(eslint@9.39.5)
-      globals:
-        specifier: ^17.3.0
-        version: 17.9.0
       prettier:
         specifier: ^3.8.1
         version: 3.9.6
@@ -1679,10 +1676,6 @@ packages:
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
-    engines: {node: '>=18'}
-
-  globals@17.9.0:
-    resolution: {integrity: sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==}
     engines: {node: '>=18'}
 
   globalthis@1.0.4:
@@ -4430,8 +4423,6 @@ snapshots:
       path-scurry: 2.0.2
 
   globals@14.0.0: {}
-
-  globals@17.9.0: {}
 
   globalthis@1.0.4:
     dependencies:


### PR DESCRIPTION
## summary

- replace the deprecated typescript-eslint config helper with typed ESLint flat config
- use the React JSX-runtime and Hooks presets with minimal file scoping
- remove redundant options, globals, rule overrides, and CLI extension flags

## checks

- pnpm exec tsc --allowJs --checkJs --noEmit --module NodeNext --moduleResolution NodeNext --target ESNext --skipLibCheck eslint.config.js
- pnpm check:quality
- eslint --print-config src/components/Input/Input.tsx
- git diff --check