### PR TITLE
✨ feat(storybook): add themed component states

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -2,6 +2,7 @@ import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.stories.tsx'],
+  addons: ['@storybook/addon-themes'],
   framework: '@storybook/react-vite',
   viteFinal: async (viteConfig) => {
     viteConfig.plugins = viteConfig.plugins?.filter(

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,1 +1,0 @@
-import './preview.css';

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,0 +1,49 @@
+import * as stylex from '@stylexjs/stylex';
+import { withThemeFromJSXProvider } from '@storybook/addon-themes';
+import type { Preview } from '@storybook/react-vite';
+import type { PropsWithChildren } from 'react';
+import { Theme } from '../src/components/Theme';
+import { colors } from '../src/theme/colors.stylex';
+import { spacing } from '../src/theme/foundations.stylex';
+import './preview.css';
+
+type StorybookTheme = {
+  mode: 'light' | 'dark';
+};
+
+const themes = {
+  light: { mode: 'light' },
+  dark: { mode: 'dark' }
+} satisfies Record<string, StorybookTheme>;
+
+const styles = stylex.create({
+  canvas: {
+    backgroundColor: colors.surface,
+    boxSizing: 'border-box',
+    minHeight: '100vh',
+    padding: spacing.lg
+  }
+});
+
+function ThemeProvider({ children, theme }: PropsWithChildren<{ theme: StorybookTheme }>) {
+  return (
+    <Theme mode={theme.mode}>
+      <div {...stylex.props(styles.canvas)}>{children}</div>
+    </Theme>
+  );
+}
+
+const preview: Preview = {
+  decorators: [
+    withThemeFromJSXProvider({
+      themes,
+      defaultTheme: 'light',
+      Provider: ThemeProvider
+    })
+  ],
+  parameters: {
+    layout: 'fullscreen'
+  }
+};
+
+export default preview;

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.3",
+    "@storybook/addon-themes": "10.5.2",
     "@storybook/react-vite": "10.5.2",
     "@stylexjs/stylex": "^0.19.0",
     "@stylexjs/unplugin": "^0.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.3
         version: 9.39.5
+      '@storybook/addon-themes':
+        specifier: 10.5.2
+        version: 10.5.2(storybook@10.5.2(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))
       '@storybook/react-vite':
         specifier: 10.5.2
         version: 10.5.2(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rollup@4.62.4)(storybook@10.5.2(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(typescript@5.9.3)(vite@7.3.6(@types/node@25.9.5)(lightningcss@1.33.0))
@@ -861,6 +864,11 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@storybook/addon-themes@10.5.2':
+    resolution: {integrity: sha512-XxqGlGFOw8lXhlkxftmq2ifsGeKLM8YePhVzdmG52XCHWN5sPJx9ns4QWOPqSs5669QlKUDo6Ct8c8cN6BmznA==}
+    peerDependencies:
+      storybook: ^10.5.2
 
   '@storybook/builder-vite@10.5.2':
     resolution: {integrity: sha512-XxY/zpMrEOXqdJaEw8s7fJefDCjO1eRkjvZvb50ojiqDJpTdfguhBrwqlHilpWWt5a12VjbbMrUHza4YPs/bBg==}
@@ -3357,6 +3365,11 @@ snapshots:
       - '@types/node'
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@storybook/addon-themes@10.5.2(storybook@10.5.2(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))':
+    dependencies:
+      storybook: 10.5.2(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
+      ts-dedent: 2.3.0
 
   '@storybook/builder-vite@10.5.2(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.5.2(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@7.3.6(@types/node@25.9.5)(lightningcss@1.33.0))':
     dependencies:

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,9 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Button } from './Button';
 
-export default {
-  component: Button
-};
+const meta = {
+  title: 'Components/Button',
+  component: Button,
+  args: {
+    children: 'Button'
+  }
+} satisfies Meta<typeof Button>;
 
-export const Default = {
-  args: { children: 'Button' }
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true
+  }
 };

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -19,8 +19,13 @@ const styles = stylex.create({
       ':enabled:hover': colors.primaryHover,
       ':disabled': colors.surfaceDisabled
     },
+    borderColor: {
+      default: 'transparent',
+      ':disabled': colors.borderDisabled
+    },
     borderRadius: radii.sm,
-    borderStyle: 'none',
+    borderStyle: 'solid',
+    borderWidth: '1px',
     boxSizing: 'border-box',
     color: {
       default: colors.onEmphasis,

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -1,9 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Input } from './Input';
 
-export default {
-  component: Input
+const meta = {
+  title: 'Components/Input',
+  component: Input,
+  args: {
+    'aria-label': 'Example input',
+    placeholder: 'Input'
+  }
+} satisfies Meta<typeof Input>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithValue: Story = {
+  args: {
+    defaultValue: 'Input value'
+  }
 };
 
-export const Default = {
-  args: { placeholder: 'Input' }
+export const Disabled: Story = {
+  args: {
+    disabled: true
+  }
 };

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -18,7 +18,10 @@ const styles = stylex.create({
       default: colors.surface,
       ':disabled': colors.surfaceDisabled
     },
-    borderColor: colors.border,
+    borderColor: {
+      default: colors.border,
+      ':disabled': colors.borderDisabled
+    },
     borderRadius: radii.sm,
     borderStyle: 'solid',
     borderWidth: '1px',

--- a/src/components/Typography/Typography.stories.tsx
+++ b/src/components/Typography/Typography.stories.tsx
@@ -1,9 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Typography } from './Typography';
 
-export default {
-  component: Typography
+const meta = {
+  title: 'Components/Typography',
+  component: Typography,
+  args: {
+    children: 'Typography'
+  }
+} satisfies Meta<typeof Typography>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Heading1: Story = {
+  args: {
+    children: 'Heading 1',
+    variant: 'h1'
+  }
 };
 
-export const Default = {
-  args: { children: 'Typography' }
+export const Heading2: Story = {
+  args: {
+    children: 'Heading 2',
+    variant: 'h2'
+  }
 };

--- a/src/theme/colors.stylex.ts
+++ b/src/theme/colors.stylex.ts
@@ -6,6 +6,7 @@ export const colors = stylex.defineVars({
   text: palette.gray900,
   textMuted: palette.gray600,
   border: palette.gray600,
+  borderDisabled: palette.gray400,
   primary: palette.blue600,
   primaryHover: palette.blue700,
   onEmphasis: palette.gray50,

--- a/src/theme/themes.ts
+++ b/src/theme/themes.ts
@@ -9,6 +9,7 @@ export const darkTheme = stylex.createTheme(colors, {
   text: palette.gray50,
   textMuted: palette.gray400,
   border: palette.gray400,
+  borderDisabled: palette.gray600,
   primary: palette.blue500,
   primaryHover: palette.blue400,
   onEmphasis: palette.gray950,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,12 @@
     "noFallthroughCasesInSwitch": true,
     "types": ["node", "vitest/globals", "vite/client"]
   },
-  "include": ["src", ".storybook/**/*.ts", "vite.config.ts", "vitest*.ts", "vitest*.config.ts"]
+  "include": [
+    "src",
+    ".storybook/**/*.ts",
+    ".storybook/**/*.tsx",
+    "vite.config.ts",
+    "vitest*.ts",
+    "vitest*.config.ts"
+  ]
 }


### PR DESCRIPTION
## summary

- add light and dark Storybook previews backed by the shared Theme component
- expand component stories and style disabled borders with semantic theme tokens

## checks

- `pnpm check:quality`